### PR TITLE
Fix (#13454): Edited GetClearGround(Tile t) function

### DIFF
--- a/bin/ai/compat_14.nut
+++ b/bin/ai/compat_14.nut
@@ -8,3 +8,31 @@
 /* This file contains code to downgrade the API from 15 to 14. */
 
 AIBridge.GetBridgeID <- AIBridge.GetBridgeType;
+
+class AICompat14 {
+	function Text(text)
+	{
+		if (typeof(text) != "string") return null;
+		return text;
+	}
+}
+
+AIBaseStation._SetName <- AIBaseStation.SetName;
+AIBaseStation.SetName <- function(id, name) { return AIBaseStation._SetName(id, AICompat14.Text(name)); }
+
+AICompany._SetName <- AICompany.SetName;
+AICompany.SetName <- function(name) { return AICompany._SetName(AICompat14.Text(name)); }
+AICompany._SetPresidentName <- AICompany.SetPresidentName;
+AICompany.SetPresidentName <- function(name) { return AICompany._SetPresidentName(AICompat14.Text(name)); }
+
+AIGroup._SetName <- AIGroup.SetName;
+AIGroup.SetName <- function(name) { return AIGroup._SetName(AICompat14.Text(name)); }
+
+AISign._BuildSign <- AISign.BuildSign;
+AISign.BuildSign <- function(id, name) { return AISign._BuildSign(id, AICompat14.Text(name)); }
+
+AITown._FoundTown <- AITown.FoundTown;
+AITown.FoundTown <- function(tile, size, city, layout, name) { return AITown._FoundTown(tile, size, city, layout, AICompat14.Text(name)); }
+
+AIVehicle._SetName <- AIVehicle.SetName;
+AIVehicle.SetName <- function(id, name) { return AIVehicle._SetName(id, AICompat14.Text(name)); }

--- a/bin/game/compat_14.nut
+++ b/bin/game/compat_14.nut
@@ -8,3 +8,73 @@
 /* This file contains code to downgrade the API from 15 to 14. */
 
 GSBridge.GetBridgeID <- GSBridge.GetBridgeType;
+
+class GSCompat14 {
+	function Text(text)
+	{
+		type = typeof(text)
+		if (type != "string" && type != "GSText") return null;
+		return text;
+	}
+}
+
+GSBaseStation._SetName <- GSBaseStation.SetName;
+GSBaseStation.SetName <- function(id, name) { return GSBaseStation._SetName(id, GSCompat14.Text(name)); }
+
+GSCompany._SetName <- GSCompany.SetName;
+GSCompany.SetName <- function(name) { return GSCompany._SetName(GSCompat14.Text(name)); }
+GSCompany._SetPresidentName <- GSCompany.SetPresidentName;
+GSCompany.SetPresidentName <- function(name) { return GSCompany._SetPresidentName(GSCompat14.Text(name)); }
+
+GSGoal._New <- GSGoal.New;
+GSGoal.New <- function(company, goal, type, dest) { return GSGoal._New(company, GSCompat14.Text(goal), type, dest); }
+GSGoal._SetText <- GSGoal.SetText;
+GSGoal.SetText <- function(id, goal) { return GSGoal._SetText(id, GSCompat14.Text(goal)); }
+GSGoal._SetProgress <- GSGoal.SetProgress;
+GSGoal.SetProgress <- function(id, progress) { return GSGoal._SetProgress(id, GSCompat14.Text(progress)); }
+GSGoal._Question <- GSGoal.Question;
+GSGoal.Question <- function(id, company, question, type, buttons) { return GSGoal._Question(id, company, GSCompat14.Text(question), type, buttons); }
+GSGoal._QuestionClient <- GSGoal.QuestionClient;
+GSGoal.QuestionClient <- function(id, target, is_client, question, type, buttons) { return GSGoal._QuestionClient(id, target, is_client, GSCompat14.Text(question), type, buttons); }
+
+GSGroup._SetName <- GSGroup.SetName;
+GSGroup.SetName <- function(name) { return GSGroup._SetName(GSCompat14.Text(name)); }
+
+GSIndustry._SetText <- GSIndustry.SetText;
+GSIndustry.SetText <- function(id, text) { return GSIndustry._SetText(id, GSCompat14.Text(text)); }
+GSIndustry._SetProductionLevel <- GSIndustry.SetProductionLevel;
+GSIndustry.SetProductionLevel <- function(id, level, news, text) { return GSIndustry._SetProductionLevel(id, level, news, GSCompat14.Text(text)); }
+
+GSLeagueTable._New <- GSLeagueTable.New;
+GSLeagueTable.New <- function(title, header, footer) { return GSLeagueTable._New(GSCompat14.Text(title), GSCompat14.Text(header), GSCompat14.Text(footer)); }
+GSLeagueTable._NewElement <- GSLeagueTable.NewElement;
+GSLeagueTable.NewElement <- function(table, rating, company, text, score, type, target) { return GSLeagueTable._NewElement(table, rating, company, GSCompat14.Text(text), GSCompat14.Text(score), type, target); }
+GSLeagueTable._UpdateElementData <- GSLeagueTable.UpdateElementData;
+GSLeagueTable.UpdateElementData <- function(element, company, text, type, target) { return GSLeagueTable._UpdateElementData(element, company, GSCompat14.Text(text), type, target); }
+GSLeagueTable._UpdateElementScore <- GSLeagueTable.UpdateElementScore;
+GSLeagueTable.UpdateElementScore <- function(element, rating, score) { return GSLeagueTable._UpdateElementScore(element, rating, GSCompat14.Text(score)); }
+
+GSNews._Create <- GSNews.Create;
+GSNews.Create <- function(type, text, company, ref_type, ref) { return GSNews._Create(type, GSCompat14.Text(text), company, ref_type, ref); }
+
+GSSign._BuildSign <- GSSign.BuildSign;
+GSSign.BuildSign <- function(id, name) { return GSSign._BuildSign(id, GSCompat14.Text(name)); }
+
+GSStoryPage._New <- GSStoryPage.New;
+GSStoryPage.New <- function(company, title) { return GSStoryPage._New(company, GSCompat14.Text(title)); }
+GSStoryPage._NewElement <- GSStoryPage.NewElement;
+GSStoryPage.NewElement <- function(page, type, ref, text) { return GSStoryPage._NewElement(page, type, ref, GSCompat14.Text(text)); }
+GSStoryPage._UpdateElement <- GSStoryPage.UpdateElement;
+GSStoryPage.UpdateElement <- function(id, ref, text) { return GSStoryPage._UpdateElement(id, ref, GSCompat14.Text(text)); }
+GSStoryPage._SetTitle <- GSStoryPage.SetTitle;
+GSStoryPage.SetTitle <- function(page, tile) { return GSStoryPage._SetTitle(page, GSCompat14.Text(title)); }
+
+GSTown._SetName <- GSTown.SetName;
+GSTown.SetName <- function(id, name) { return GSTown._SetName(id, GSCompat14.Text(name)); }
+GSTown._SetText <- GSTown.SetText;
+GSTown.SetText <- function(id, text) { return GSTown._SetText(id, GSCompat14.Text(text)); }
+GSTown._FoundTown <- GSTown.FoundTown;
+GSTown.FoundTown <- function(tile, size, city, layout, name) { return GSTown._FoundTown(tile, size, city, layout, GSCompat14.Text(name)); }
+
+GSVehicle._SetName <- GSVehicle.SetName;
+GSVehicle.SetName <- function(id, name) { return GSVehicle._SetName(id, GSCompat14.Text(name)); }

--- a/cmake/scripts/SquirrelExport.cmake
+++ b/cmake/scripts/SquirrelExport.cmake
@@ -340,7 +340,7 @@ foreach(LINE IN LISTS SOURCE_LINES)
         endif()
 
         string(APPEND SQUIRREL_EXPORT "\n")
-        string(APPEND SQUIRREL_EXPORT "\ntemplate <> const char *GetClassName<${CLS}, ScriptType::${APIUC}>() { return \"${API_CLS}\"; }")
+        string(APPEND SQUIRREL_EXPORT "\ntemplate <> SQInteger PushClassName<${CLS}, ScriptType::${APIUC}>(HSQUIRRELVM vm) { sq_pushstring(vm, \"${API_CLS}\", -1); return 1; }")
         string(APPEND SQUIRREL_EXPORT "\n")
 
         # Then do the registration functions of the class.
@@ -484,9 +484,8 @@ foreach(LINE IN LISTS SOURCE_LINES)
                 string(APPEND SQUIRREL_EXPORT "\n	SQ${API_CLS}.DefSQStaticMethod(engine, &${CLS}::${FUNCNAME},${SPACES}\"${FUNCNAME}\",${SPACES}${ARGC}, \"${TYPES}\");")
             endif()
         endforeach()
-        if(MLEN)
-            string(APPEND SQUIRREL_EXPORT "\n")
-        endif()
+        string(APPEND SQUIRREL_EXPORT "\n	SQ${API_CLS}.DefSQAdvancedStaticMethod(engine, &PushClassName<${CLS}, ScriptType::${APIUC}>, \"_typeof\");")
+        string(APPEND SQUIRREL_EXPORT "\n")
 
         # Non-static methods
         set(MLEN 0)

--- a/src/ai/ai_info.cpp
+++ b/src/ai/ai_info.cpp
@@ -27,10 +27,7 @@ static bool CheckAPIVersion(const std::string &api_version)
 	return std::ranges::find(AIInfo::ApiVersions, api_version) != std::end(AIInfo::ApiVersions);
 }
 
-#if defined(_WIN32)
-#undef GetClassName
-#endif /* _WIN32 */
-template <> const char *GetClassName<AIInfo, ScriptType::AI>() { return "AIInfo"; }
+template <> SQInteger PushClassName<AIInfo, ScriptType::AI>(HSQUIRRELVM vm) { sq_pushstring(vm, "AIInfo", -1); return 1; }
 
 /* static */ void AIInfo::RegisterAPI(Squirrel *engine)
 {
@@ -38,6 +35,7 @@ template <> const char *GetClassName<AIInfo, ScriptType::AI>() { return "AIInfo"
 	DefSQClass<AIInfo, ScriptType::AI> SQAIInfo("AIInfo");
 	SQAIInfo.PreRegister(engine);
 	SQAIInfo.AddConstructor<void (AIInfo::*)(), 1>(engine, "x");
+	SQAIInfo.DefSQAdvancedStaticMethod(engine, &PushClassName<AIInfo, ScriptType::AI>, "_typeof");
 	SQAIInfo.DefSQAdvancedMethod(engine, &AIInfo::AddSetting, "AddSetting");
 	SQAIInfo.DefSQAdvancedMethod(engine, &AIInfo::AddLabels, "AddLabels");
 	SQAIInfo.DefSQConst(engine, SCRIPTCONFIG_NONE, "CONFIG_NONE");

--- a/src/aircraft.h
+++ b/src/aircraft.h
@@ -62,25 +62,25 @@ int GetAircraftFlightLevel(T *v, bool takeoff = false);
 
 /** Variables that are cached to improve performance and such. */
 struct AircraftCache {
-	uint32_t cached_max_range_sqr;   ///< Cached squared maximum range.
-	uint16_t cached_max_range;       ///< Cached maximum range.
+	uint32_t cached_max_range_sqr = 0; ///< Cached squared maximum range.
+	uint16_t cached_max_range = 0; ///< Cached maximum range.
 };
 
 /**
  * Aircraft, helicopters, rotors and their shadows belong to this class.
  */
 struct Aircraft final : public SpecializedVehicle<Aircraft, VEH_AIRCRAFT> {
-	uint16_t crashed_counter;        ///< Timer for handling crash animations.
-	uint8_t pos;                      ///< Next desired position of the aircraft.
-	uint8_t previous_pos;             ///< Previous desired position of the aircraft.
-	StationID targetairport;       ///< Airport to go to next.
-	uint8_t state;                    ///< State of the airport. @see AirportMovementStates
-	Direction last_direction;
-	uint8_t number_consecutive_turns; ///< Protection to prevent the aircraft of making a lot of turns in order to reach a specific point.
-	uint8_t turn_counter;             ///< Ticks between each turn to prevent > 45 degree turns.
-	uint8_t flags;                    ///< Aircraft flags. @see AirVehicleFlags
+	uint16_t crashed_counter = 0; ///< Timer for handling crash animations.
+	uint8_t pos = 0; ///< Next desired position of the aircraft.
+	uint8_t previous_pos = 0; ///< Previous desired position of the aircraft.
+	StationID targetairport = StationID::Invalid(); ///< Airport to go to next.
+	uint8_t state = 0; ///< State of the airport. @see AirportMovementStates
+	Direction last_direction = INVALID_DIR;
+	uint8_t number_consecutive_turns = 0; ///< Protection to prevent the aircraft of making a lot of turns in order to reach a specific point.
+	uint8_t turn_counter = 0; ///< Ticks between each turn to prevent > 45 degree turns.
+	uint8_t flags = 0; ///< Aircraft flags. @see AirVehicleFlags
 
-	AircraftCache acache;
+	AircraftCache acache{};
 
 	/** We don't want GCC to zero our struct! It already is zeroed and has an index! */
 	Aircraft() : SpecializedVehicleBase() {}

--- a/src/base_consist.h
+++ b/src/base_consist.h
@@ -15,23 +15,23 @@
 
 /** Various front vehicle properties that are preserved when autoreplacing, using order-backup or switching front engines within a consist. */
 struct BaseConsist {
-	std::string name;                   ///< Name of vehicle
+	std::string name{}; ///< Name of vehicle
 
 	/* Used for timetabling. */
-	TimerGameTick::Ticks current_order_time;    ///< How many ticks have passed since this order started.
-	TimerGameTick::Ticks lateness_counter;      ///< How many ticks late (or early if negative) this vehicle is.
-	TimerGameTick::TickCounter timetable_start; ///< At what tick of TimerGameTick::counter the vehicle should start its timetable.
+	TimerGameTick::Ticks current_order_time{}; ///< How many ticks have passed since this order started.
+	TimerGameTick::Ticks lateness_counter{}; ///< How many ticks late (or early if negative) this vehicle is.
+	TimerGameTick::TickCounter timetable_start{}; ///< At what tick of TimerGameTick::counter the vehicle should start its timetable.
 
-	TimerGameTick::TickCounter depot_unbunching_last_departure; ///< When the vehicle last left its unbunching depot.
-	TimerGameTick::TickCounter depot_unbunching_next_departure; ///< When the vehicle will next try to leave its unbunching depot.
+	TimerGameTick::TickCounter depot_unbunching_last_departure{}; ///< When the vehicle last left its unbunching depot.
+	TimerGameTick::TickCounter depot_unbunching_next_departure{}; ///< When the vehicle will next try to leave its unbunching depot.
 	TimerGameTick::Ticks round_trip_time;  ///< How many ticks for a single circumnavigation of the orders.
 
-	uint16_t service_interval;            ///< The interval for (automatic) servicing; either in days or %.
+	uint16_t service_interval = 0; ///< The interval for (automatic) servicing; either in days or %.
 
-	VehicleOrderID cur_real_order_index;///< The index to the current real (non-implicit) order
-	VehicleOrderID cur_implicit_order_index;///< The index to the current implicit order
+	VehicleOrderID cur_real_order_index = 0; ///< The index to the current real (non-implicit) order
+	VehicleOrderID cur_implicit_order_index = 0; ///< The index to the current implicit order
 
-	uint16_t vehicle_flags;               ///< Used for gradual loading and other miscellaneous things (@see VehicleFlags enum)
+	uint16_t vehicle_flags = 0; ///< Used for gradual loading and other miscellaneous things (@see VehicleFlags enum)
 
 	virtual ~BaseConsist() = default;
 

--- a/src/base_station_base.h
+++ b/src/base_station_base.h
@@ -21,15 +21,15 @@ extern StationPool _station_pool;
 
 template <typename T>
 struct SpecMapping {
-	const T *spec; ///< Custom spec.
-	uint32_t grfid; ///< GRF ID of this custom spec.
-	uint16_t localidx; ///< Local ID within GRF of this custom spec.
+	const T *spec = nullptr; ///< Custom spec.
+	uint32_t grfid = 0; ///< GRF ID of this custom spec.
+	uint16_t localidx = 0; ///< Local ID within GRF of this custom spec.
 };
 
 struct RoadStopTileData {
-	TileIndex tile;
-	uint8_t random_bits;
-	uint8_t animation_frame;
+	TileIndex tile = INVALID_TILE;
+	uint8_t random_bits = 0;
+	uint8_t animation_frame = 0;
 };
 
 /** StationRect - used to track station spread out rectangle - cheaper than scanning whole map */
@@ -56,44 +56,40 @@ struct StationRect : public Rect {
 
 /** Base class for all station-ish types */
 struct BaseStation : StationPool::PoolItem<&_station_pool> {
-	TileIndex xy;                   ///< Base tile of the station
-	TrackedViewportSign sign;       ///< NOSAVE: Dimensions of sign
-	uint8_t delete_ctr;                ///< Delete counter. If greater than 0 then it is decremented until it reaches 0; the waypoint is then is deleted.
+	TileIndex xy = INVALID_TILE; ///< Base tile of the station
+	TrackedViewportSign sign{}; ///< NOSAVE: Dimensions of sign
+	uint8_t delete_ctr = 0; ///< Delete counter. If greater than 0 then it is decremented until it reaches 0; the waypoint is then is deleted.
 
-	std::string name;               ///< Custom name
-	StringID string_id;             ///< Default name (town area) of station
+	std::string name{}; ///< Custom name
+	StringID string_id = INVALID_STRING_ID; ///< Default name (town area) of station
 	mutable std::string cached_name; ///< NOSAVE: Cache of the resolved name of the station, if not using a custom name
 
-	Town *town;                     ///< The town this station is associated with
-	Owner owner;                    ///< The owner of this station
-	StationFacilities facilities;     ///< The facilities that this station has
+	Town *town = nullptr; ///< The town this station is associated with
+	Owner owner = INVALID_OWNER; ///< The owner of this station
+	StationFacilities facilities{}; ///< The facilities that this station has
 
-	std::vector<SpecMapping<StationSpec>> speclist;           ///< List of rail station specs of this station.
-	std::vector<SpecMapping<RoadStopSpec>> roadstop_speclist; ///< List of road stop specs of this station
+	std::vector<SpecMapping<StationSpec>> speclist{}; ///< List of rail station specs of this station.
+	std::vector<SpecMapping<RoadStopSpec>> roadstop_speclist{}; ///< List of road stop specs of this station
 
-	TimerGameCalendar::Date build_date; ///< Date of construction
+	TimerGameCalendar::Date build_date{}; ///< Date of construction
 
-	uint16_t random_bits;             ///< Random bits assigned to this station
-	uint8_t waiting_triggers;          ///< Waiting triggers (NewGRF) for this station
-	uint8_t cached_anim_triggers;                ///< NOSAVE: Combined animation trigger bitmask, used to determine if trigger processing should happen.
-	uint8_t cached_roadstop_anim_triggers;       ///< NOSAVE: Combined animation trigger bitmask for road stops, used to determine if trigger processing should happen.
-	CargoTypes cached_cargo_triggers;          ///< NOSAVE: Combined cargo trigger bitmask
-	CargoTypes cached_roadstop_cargo_triggers; ///< NOSAVE: Combined cargo trigger bitmask for road stops
+	uint16_t random_bits = 0; ///< Random bits assigned to this station
+	uint8_t waiting_triggers = 0; ///< Waiting triggers (NewGRF) for this station
+	uint8_t cached_anim_triggers = 0; ///< NOSAVE: Combined animation trigger bitmask, used to determine if trigger processing should happen.
+	uint8_t cached_roadstop_anim_triggers = 0; ///< NOSAVE: Combined animation trigger bitmask for road stops, used to determine if trigger processing should happen.
+	CargoTypes cached_cargo_triggers{}; ///< NOSAVE: Combined cargo trigger bitmask
+	CargoTypes cached_roadstop_cargo_triggers{}; ///< NOSAVE: Combined cargo trigger bitmask for road stops
 
-	TileArea train_station;         ///< Tile area the train 'station' part covers
-	StationRect rect;               ///< NOSAVE: Station spread out rectangle maintained by StationRect::xxx() functions
+	TileArea train_station{INVALID_TILE, 0, 0}; ///< Tile area the train 'station' part covers
+	StationRect rect{}; ///< NOSAVE: Station spread out rectangle maintained by StationRect::xxx() functions
 
-	std::vector<RoadStopTileData> custom_roadstop_tile_data; ///< List of custom road stop tile data
+	std::vector<RoadStopTileData> custom_roadstop_tile_data{}; ///< List of custom road stop tile data
 
 	/**
 	 * Initialize the base station.
 	 * @param tile The location of the station sign
 	 */
-	BaseStation(TileIndex tile) :
-		xy(tile),
-		train_station(INVALID_TILE, 0, 0)
-	{
-	}
+	BaseStation(TileIndex tile) : xy(tile) {}
 
 	virtual ~BaseStation();
 

--- a/src/clear_map.h
+++ b/src/clear_map.h
@@ -58,6 +58,7 @@ inline ClearGround GetRawClearGround(Tile t)
  */
 inline ClearGround GetClearGround(Tile t)
 {
+	if (GetRawClearGround(t) == CLEAR_ROCKS) return CLEAR_ROCKS;
 	if (IsSnowTile(t)) return CLEAR_SNOW;
 	return GetRawClearGround(t);
 }

--- a/src/disaster_vehicle.h
+++ b/src/disaster_vehicle.h
@@ -35,10 +35,10 @@ enum DisasterSubType : uint8_t {
  * Disasters, like submarines, skyrangers and their shadows, belong to this class.
  */
 struct DisasterVehicle final : public SpecializedVehicle<DisasterVehicle, VEH_DISASTER> {
-	SpriteID image_override;            ///< Override for the default disaster vehicle sprite.
-	VehicleID big_ufo_destroyer_target; ///< The big UFO that this destroyer is supposed to bomb.
-	uint8_t flags;                         ///< Flags about the state of the vehicle, @see AirVehicleFlags
-	uint16_t state;                     ///< Action stage of the disaster vehicle.
+	SpriteID image_override{}; ///< Override for the default disaster vehicle sprite.
+	VehicleID big_ufo_destroyer_target = VehicleID::Invalid(); ///< The big UFO that this destroyer is supposed to bomb.
+	uint8_t flags = 0; ///< Flags about the state of the vehicle, @see AirVehicleFlags
+	uint16_t state = 0; ///< Action stage of the disaster vehicle.
 
 	/** For use by saveload. */
 	DisasterVehicle() : SpecializedVehicleBase() {}

--- a/src/game/game_info.cpp
+++ b/src/game/game_info.cpp
@@ -25,10 +25,7 @@ static bool CheckAPIVersion(const std::string &api_version)
 	return std::ranges::find(GameInfo::ApiVersions, api_version) != std::end(GameInfo::ApiVersions);
 }
 
-#if defined(_WIN32)
-#undef GetClassName
-#endif /* _WIN32 */
-template <> const char *GetClassName<GameInfo, ScriptType::GS>() { return "GSInfo"; }
+template <> SQInteger PushClassName<GameInfo, ScriptType::GS>(HSQUIRRELVM vm) { sq_pushstring(vm, "GSInfo", -1); return 1; }
 
 /* static */ void GameInfo::RegisterAPI(Squirrel *engine)
 {
@@ -36,6 +33,7 @@ template <> const char *GetClassName<GameInfo, ScriptType::GS>() { return "GSInf
 	DefSQClass<GameInfo, ScriptType::GS> SQGSInfo("GSInfo");
 	SQGSInfo.PreRegister(engine);
 	SQGSInfo.AddConstructor<void (GameInfo::*)(), 1>(engine, "x");
+	SQGSInfo.DefSQAdvancedStaticMethod(engine, &PushClassName<GameInfo, ScriptType::GS>, "_typeof");
 	SQGSInfo.DefSQAdvancedMethod(engine, &GameInfo::AddSetting, "AddSetting");
 	SQGSInfo.DefSQAdvancedMethod(engine, &GameInfo::AddLabels, "AddLabels");
 	SQGSInfo.DefSQConst(engine, SCRIPTCONFIG_NONE, "CONFIG_NONE");

--- a/src/goal.cpp
+++ b/src/goal.cpp
@@ -85,12 +85,7 @@ std::tuple<CommandCost, GoalID> CmdCreateGoal(DoCommandFlags flags, CompanyID co
 	if (!Goal::IsValidGoalDestination(company, type, dest)) return { CMD_ERROR, GoalID::Invalid() };
 
 	if (flags.Test(DoCommandFlag::Execute)) {
-		Goal *g = new Goal();
-		g->type = type;
-		g->dst = dest;
-		g->company = company;
-		g->text = text;
-		g->completed = false;
+		Goal *g = new Goal(type, dest, company, text);
 
 		if (g->company == CompanyID::Invalid()) {
 			InvalidateWindowClassesData(WC_GOALS_LIST);

--- a/src/goal_base.h
+++ b/src/goal_base.h
@@ -19,22 +19,23 @@ extern GoalPool _goal_pool;
 
 /** Struct about goals, current and completed */
 struct Goal : GoalPool::PoolItem<&_goal_pool> {
-	CompanyID company;    ///< Goal is for a specific company; CompanyID::Invalid() if it is global
-	GoalType type;        ///< Type of the goal
-	GoalTypeID dst;       ///< Index of type
-	std::string text;     ///< Text of the goal.
-	std::string progress; ///< Progress text of the goal.
-	bool completed;       ///< Is the goal completed or not?
+	CompanyID company = CompanyID::Invalid(); ///< Goal is for a specific company; CompanyID::Invalid() if it is global
+	GoalType type = GT_NONE; ///< Type of the goal
+	GoalTypeID dst = 0; ///< Index of type
+	std::string text{}; ///< Text of the goal.
+	std::string progress{}; ///< Progress text of the goal.
+	bool completed = false; ///< Is the goal completed or not?
 
 	/**
 	 * We need an (empty) constructor so struct isn't zeroed (as C++ standard states)
 	 */
-	inline Goal() { }
+	Goal() { }
+	Goal(GoalType type, GoalTypeID dst, CompanyID company, const std::string &text) : company(company), type(type), dst(dst), text(text) {}
 
 	/**
 	 * (Empty) destructor has to be defined else operator delete might be called with nullptr parameter
 	 */
-	inline ~Goal() { }
+	~Goal() { }
 
 	static bool IsValidGoalDestination(CompanyID company, GoalType type, GoalTypeID dest);
 };

--- a/src/ground_vehicle.hpp
+++ b/src/ground_vehicle.hpp
@@ -29,23 +29,23 @@ enum AccelStatus : uint8_t {
  */
 struct GroundVehicleCache {
 	/* Cached acceleration values, recalculated when the cargo on a vehicle changes (in addition to the conditions below) */
-	uint32_t cached_weight;           ///< Total weight of the consist (valid only for the first engine).
-	uint32_t cached_slope_resistance; ///< Resistance caused by weight when this vehicle part is at a slope.
-	uint32_t cached_max_te;           ///< Maximum tractive effort of consist (valid only for the first engine).
-	uint16_t cached_axle_resistance;  ///< Resistance caused by the axles of the vehicle (valid only for the first engine).
+	uint32_t cached_weight = 0; ///< Total weight of the consist (valid only for the first engine).
+	uint32_t cached_slope_resistance = 0; ///< Resistance caused by weight when this vehicle part is at a slope.
+	uint32_t cached_max_te = 0; ///< Maximum tractive effort of consist (valid only for the first engine).
+	uint16_t cached_axle_resistance = 0; ///< Resistance caused by the axles of the vehicle (valid only for the first engine).
 
 	/* Cached acceleration values, recalculated on load and each time a vehicle is added to/removed from the consist. */
-	uint16_t cached_max_track_speed;  ///< Maximum consist speed (in internal units) limited by track type (valid only for the first engine).
-	uint32_t cached_power;            ///< Total power of the consist (valid only for the first engine).
-	uint32_t cached_air_drag;         ///< Air drag coefficient of the vehicle (valid only for the first engine).
+	uint16_t cached_max_track_speed = 0; ///< Maximum consist speed (in internal units) limited by track type (valid only for the first engine).
+	uint32_t cached_power = 0; ///< Total power of the consist (valid only for the first engine).
+	uint32_t cached_air_drag = 0; ///< Air drag coefficient of the vehicle (valid only for the first engine).
 
 	/* Cached NewGRF values, recalculated on load and each time a vehicle is added to/removed from the consist. */
-	uint16_t cached_total_length;     ///< Length of the whole vehicle (valid only for the first engine).
-	EngineID first_engine;          ///< Cached EngineID of the front vehicle. EngineID::Invalid() for the front vehicle itself.
-	uint8_t cached_veh_length;        ///< Length of this vehicle in units of 1/VEHICLE_LENGTH of normal length. It is cached because this can be set by a callback.
+	uint16_t cached_total_length = 0; ///< Length of the whole vehicle (valid only for the first engine).
+	EngineID first_engine = EngineID::Invalid(); ///< Cached EngineID of the front vehicle. EngineID::Invalid() for the front vehicle itself.
+	uint8_t cached_veh_length = 0; ///< Length of this vehicle in units of 1/VEHICLE_LENGTH of normal length. It is cached because this can be set by a callback.
 
 	/* Cached UI information. */
-	uint16_t last_speed;              ///< The last speed we did display, so we only have to redraw when this changes.
+	uint16_t last_speed = 0; ///< The last speed we did display, so we only have to redraw when this changes.
 
 	auto operator<=>(const GroundVehicleCache &) const = default;
 };
@@ -80,8 +80,8 @@ enum GroundVehicleFlags : uint8_t {
  */
 template <class T, VehicleType Type>
 struct GroundVehicle : public SpecializedVehicle<T, Type> {
-	GroundVehicleCache gcache; ///< Cache of often calculated values.
-	uint16_t gv_flags;           ///< @see GroundVehicleFlags.
+	GroundVehicleCache gcache{}; ///< Cache of often calculated values.
+	uint16_t gv_flags = 0; ///< @see GroundVehicleFlags.
 
 	typedef GroundVehicle<T, Type> GroundVehicleBase; ///< Our type
 

--- a/src/group.h
+++ b/src/group.h
@@ -22,13 +22,13 @@ extern GroupPool _group_pool; ///< Pool of groups.
 
 /** Statistics and caches on the vehicles in a group. */
 struct GroupStatistics {
-	Money profit_last_year;                 ///< Sum of profits for all vehicles.
-	Money profit_last_year_min_age;         ///< Sum of profits for vehicles considered for profit statistics.
-	std::map<EngineID, uint16_t> num_engines; ///< Caches the number of engines of each type the company owns.
-	uint16_t num_vehicle;                     ///< Number of vehicles.
-	uint16_t num_vehicle_min_age;             ///< Number of vehicles considered for profit statistics;
-	bool autoreplace_defined;               ///< Are any autoreplace rules set?
-	bool autoreplace_finished;              ///< Have all autoreplacement finished?
+	Money profit_last_year = 0; ///< Sum of profits for all vehicles.
+	Money profit_last_year_min_age = 0; ///< Sum of profits for vehicles considered for profit statistics.
+	std::map<EngineID, uint16_t> num_engines{}; ///< Caches the number of engines of each type the company owns.
+	uint16_t num_vehicle = 0; ///< Number of vehicles.
+	uint16_t num_vehicle_min_age = 0; ///< Number of vehicles considered for profit statistics;
+	bool autoreplace_defined = false; ///< Are any autoreplace rules set?
+	bool autoreplace_finished = false; ///< Have all autoreplacement finished?
 
 	void Clear();
 
@@ -70,20 +70,21 @@ using GroupFlags = EnumBitSet<GroupFlag, uint8_t>;
 
 /** Group data. */
 struct Group : GroupPool::PoolItem<&_group_pool> {
-	std::string name;           ///< Group Name
-	Owner owner;                ///< Group Owner
-	VehicleType vehicle_type;   ///< Vehicle type of the group
+	std::string name{}; ///< Group Name
+	Owner owner = INVALID_OWNER; ///< Group Owner
+	VehicleType vehicle_type = VEH_INVALID; ///< Vehicle type of the group
 
 	GroupFlags flags{}; ///< Group flags
-	Livery livery;              ///< Custom colour scheme for vehicles in this group
-	GroupStatistics statistics; ///< NOSAVE: Statistics and caches on the vehicles in the group.
+	Livery livery{}; ///< Custom colour scheme for vehicles in this group
+	GroupStatistics statistics{}; ///< NOSAVE: Statistics and caches on the vehicles in the group.
 
-	bool folded;                ///< NOSAVE: Is this group folded in the group view?
+	bool folded = false; ///< NOSAVE: Is this group folded in the group view?
 
-	GroupID parent;             ///< Parent group
-	uint16_t number; ///< Per-company group number.
+	GroupID parent = GroupID::Invalid(); ///< Parent group
+	uint16_t number = 0; ///< Per-company group number.
 
-	Group(CompanyID owner = CompanyID::Invalid());
+	Group() {}
+	Group(CompanyID owner, VehicleType vehicle_type) : owner(owner), vehicle_type(vehicle_type) {}
 };
 
 

--- a/src/group_cmd.cpp
+++ b/src/group_cmd.cpp
@@ -319,12 +319,6 @@ void UpdateCompanyGroupLiveries(const Company *c)
 	}
 }
 
-Group::Group(Owner owner)
-{
-	this->owner = owner;
-	this->folded = false;
-}
-
 
 /**
  * Create a new vehicle group.
@@ -346,9 +340,7 @@ std::tuple<CommandCost, GroupID> CmdCreateGroup(DoCommandFlags flags, VehicleTyp
 	}
 
 	if (flags.Test(DoCommandFlag::Execute)) {
-		Group *g = new Group(_current_company);
-		g->vehicle_type = vt;
-		g->parent = GroupID::Invalid();
+		Group *g = new Group(_current_company, vt);
 
 		Company *c = Company::Get(g->owner);
 		g->number = c->freegroups.UseID(c->freegroups.NextID());

--- a/src/industry.h
+++ b/src/industry.h
@@ -62,8 +62,8 @@ static const int LAST_MONTH = 1;
  */
 struct Industry : IndustryPool::PoolItem<&_industry_pool> {
 	struct ProducedHistory {
-		uint16_t production; ///< Total produced
-		uint16_t transported; ///< Total transported
+		uint16_t production = 0; ///< Total produced
+		uint16_t transported = 0; ///< Total transported
 
 		uint8_t PctTransported() const
 		{
@@ -73,51 +73,51 @@ struct Industry : IndustryPool::PoolItem<&_industry_pool> {
 	};
 
 	struct ProducedCargo {
-		CargoType cargo; ///< Cargo type
-		uint16_t waiting; ///< Amount of cargo produced
-		uint8_t rate; ///< Production rate
-		std::array<ProducedHistory, 25> history; ///< History of cargo produced and transported for this month and 24 previous months
+		CargoType cargo = 0; ///< Cargo type
+		uint16_t waiting = 0; ///< Amount of cargo produced
+		uint8_t rate = 0; ///< Production rate
+		std::array<ProducedHistory, 25> history{}; ///< History of cargo produced and transported for this month and 24 previous months
 	};
 
 	struct AcceptedCargo {
-		CargoType cargo; ///< Cargo type
-		uint16_t waiting; ///< Amount of cargo waiting to processed
-		TimerGameEconomy::Date last_accepted; ///< Last day cargo was accepted by this industry
+		CargoType cargo = 0; ///< Cargo type
+		uint16_t waiting = 0; ///< Amount of cargo waiting to processed
+		TimerGameEconomy::Date last_accepted{}; ///< Last day cargo was accepted by this industry
 	};
 
 	using ProducedCargoes = std::vector<ProducedCargo>;
 	using AcceptedCargoes = std::vector<AcceptedCargo>;
 
-	TileArea location;                                     ///< Location of the industry
-	Town *town;                                            ///< Nearest town
-	Station *neutral_station;                              ///< Associated neutral station
-	ProducedCargoes produced; ///< produced cargo slots
-	AcceptedCargoes accepted; ///< accepted cargo slots
-	uint8_t prod_level;                                       ///< general production level
-	uint16_t counter;                                        ///< used for animation and/or production (if available cargo)
+	TileArea location{INVALID_TILE, 0, 0}; ///< Location of the industry
+	Town *town = nullptr; ///< Nearest town
+	Station *neutral_station = nullptr; ///< Associated neutral station
+	ProducedCargoes produced{}; ///< produced cargo slots
+	AcceptedCargoes accepted{}; ///< accepted cargo slots
+	uint8_t prod_level = 0; ///< general production level
+	uint16_t counter = 0; ///< used for animation and/or production (if available cargo)
 
-	IndustryType type;             ///< type of industry.
-	Owner owner;                   ///< owner of the industry.  Which SHOULD always be (imho) OWNER_NONE
-	Colours random_colour;         ///< randomized colour of the industry, for display purpose
-	TimerGameEconomy::Year last_prod_year; ///< last economy year of production
-	uint8_t was_cargo_delivered;      ///< flag that indicate this has been the closest industry chosen for cargo delivery by a station. see DeliverGoodsToIndustry
-	IndustryControlFlags ctlflags; ///< flags overriding standard behaviours
+	IndustryType type = 0; ///< type of industry.
+	Owner owner = INVALID_OWNER; ///< owner of the industry.  Which SHOULD always be (imho) OWNER_NONE
+	Colours random_colour = COLOUR_BEGIN; ///< randomized colour of the industry, for display purpose
+	TimerGameEconomy::Year last_prod_year{}; ///< last economy year of production
+	uint8_t was_cargo_delivered = 0; ///< flag that indicate this has been the closest industry chosen for cargo delivery by a station. see DeliverGoodsToIndustry
+	IndustryControlFlags ctlflags{}; ///< flags overriding standard behaviours
 
-	PartOfSubsidy part_of_subsidy; ///< NOSAVE: is this industry a source/destination of a subsidy?
-	StationList stations_near;     ///< NOSAVE: List of nearby stations.
-	mutable std::string cached_name; ///< NOSAVE: Cache of the resolved name of the industry
+	PartOfSubsidy part_of_subsidy{}; ///< NOSAVE: is this industry a source/destination of a subsidy?
+	StationList stations_near{}; ///< NOSAVE: List of nearby stations.
+	mutable std::string cached_name{}; ///< NOSAVE: Cache of the resolved name of the industry
 
-	Owner founder;                 ///< Founder of the industry
-	TimerGameCalendar::Date construction_date; ///< Date of the construction of the industry
-	uint8_t construction_type;       ///< Way the industry was constructed (@see IndustryConstructionType)
-	uint8_t selected_layout;          ///< Which tile layout was used when creating the industry
-	Owner exclusive_supplier;      ///< Which company has exclusive rights to deliver cargo (INVALID_OWNER = anyone)
-	Owner exclusive_consumer;      ///< Which company has exclusive rights to take cargo (INVALID_OWNER = anyone)
-	std::string text;              ///< General text with additional information.
+	Owner founder = INVALID_OWNER; ///< Founder of the industry
+	TimerGameCalendar::Date construction_date{}; ///< Date of the construction of the industry
+	uint8_t construction_type = 0; ///< Way the industry was constructed (@see IndustryConstructionType)
+	uint8_t selected_layout = 0; ///< Which tile layout was used when creating the industry
+	Owner exclusive_supplier = INVALID_OWNER; ///< Which company has exclusive rights to deliver cargo (INVALID_OWNER = anyone)
+	Owner exclusive_consumer = INVALID_OWNER; ///< Which company has exclusive rights to take cargo (INVALID_OWNER = anyone)
+	std::string text{}; ///< General text with additional information.
 
-	uint16_t random;                 ///< Random value used for randomisation of all kinds of things
+	uint16_t random = 0; ///< Random value used for randomisation of all kinds of things
 
-	PersistentStorage *psa;        ///< Persistent storage for NewGRF industries.
+	PersistentStorage *psa = nullptr; ///< Persistent storage for NewGRF industries.
 
 	Industry(TileIndex tile = INVALID_TILE) : location(tile, 0, 0) {}
 	~Industry();

--- a/src/league_base.h
+++ b/src/league_base.h
@@ -29,17 +29,19 @@ extern LeagueTablePool _league_table_pool;
  * Each LeagueTable is composed of one or more elements. Elements are sorted by their rating (higher=better).
  **/
 struct LeagueTableElement : LeagueTableElementPool::PoolItem<&_league_table_element_pool> {
-	LeagueTableID table;  ///< Id of the table which this element belongs to
-	int64_t rating;         ///< Value that determines ordering of elements in the table (higher=better)
-	CompanyID company;    ///< Company Id to show the color blob for or CompanyID::Invalid()
-	std::string text;     ///< Text of the element
-	std::string score;    ///< String representation of the score associated with the element
-	Link link;            ///< What opens when element is clicked
+	LeagueTableID table = LeagueTableID::Invalid(); ///< Id of the table which this element belongs to
+	int64_t rating = 0; ///< Value that determines ordering of elements in the table (higher=better)
+	CompanyID company = CompanyID::Invalid(); ///< Company Id to show the color blob for or CompanyID::Invalid()
+	std::string text{}; ///< Text of the element
+	std::string score{}; ///< String representation of the score associated with the element
+	Link link{}; ///< What opens when element is clicked
 
 	/**
 	 * We need an (empty) constructor so struct isn't zeroed (as C++ standard states)
 	 */
 	LeagueTableElement() { }
+	LeagueTableElement(LeagueTableID table, int64_t rating, CompanyID company, const std::string &text, const std::string &score, const Link &link) :
+		table(table), rating(rating), company(company), text(text), score(score), link(link) {}
 
 	/**
 	 * (Empty) destructor has to be defined else operator delete might be called with nullptr parameter
@@ -50,14 +52,15 @@ struct LeagueTableElement : LeagueTableElementPool::PoolItem<&_league_table_elem
 
 /** Struct about custom league tables */
 struct LeagueTable : LeagueTablePool::PoolItem<&_league_table_pool> {
-	std::string title;  ///< Title of the table
-	std::string header;  ///< Text to show above the table
-	std::string footer;  ///< Text to show below the table
+	std::string title{}; ///< Title of the table
+	std::string header{}; ///< Text to show above the table
+	std::string footer{}; ///< Text to show below the table
 
 	/**
 	 * We need an (empty) constructor so struct isn't zeroed (as C++ standard states)
 	 */
 	LeagueTable() { }
+	LeagueTable(const std::string &title, const std::string &header, const std::string &footer) : title(title), header(header), footer(footer) { }
 
 	/**
 	 * (Empty) destructor has to be defined else operator delete might be called with nullptr parameter

--- a/src/league_cmd.cpp
+++ b/src/league_cmd.cpp
@@ -60,10 +60,7 @@ std::tuple<CommandCost, LeagueTableID> CmdCreateLeagueTable(DoCommandFlags flags
 	if (title.empty()) return { CMD_ERROR, LeagueTableID::Invalid() };
 
 	if (flags.Test(DoCommandFlag::Execute)) {
-		LeagueTable *lt = new LeagueTable();
-		lt->title = title;
-		lt->header = header;
-		lt->footer = footer;
+		LeagueTable *lt = new LeagueTable(title, header, footer);
 		return { CommandCost(), lt->index };
 	}
 
@@ -92,13 +89,7 @@ std::tuple<CommandCost, LeagueTableElementID> CmdCreateLeagueTableElement(DoComm
 	if (company != CompanyID::Invalid() && !Company::IsValidID(company)) return { CMD_ERROR, LeagueTableElementID::Invalid() };
 
 	if (flags.Test(DoCommandFlag::Execute)) {
-		LeagueTableElement *lte = new LeagueTableElement();
-		lte->table = table;
-		lte->rating = rating;
-		lte->company = company;
-		lte->text = text;
-		lte->score = score;
-		lte->link = link;
+		LeagueTableElement *lte = new LeagueTableElement(table, rating, company, text, score, link);
 		InvalidateWindowData(WC_COMPANY_LEAGUE, table);
 		return { CommandCost(), lte->index };
 	}

--- a/src/league_type.h
+++ b/src/league_type.h
@@ -25,10 +25,11 @@ enum LinkType : uint8_t {
 typedef uint32_t LinkTargetID; ///< Contains either tile, industry ID, town ID, story page ID or company ID
 
 struct Link {
-	LinkType type;
-	LinkTargetID target;
-	Link(LinkType type, LinkTargetID target): type{type}, target{target} {}
-	Link(): Link(LT_NONE, 0) {}
+	LinkType type = LT_NONE;
+	LinkTargetID target = 0;
+
+	Link() {}
+	Link(LinkType type, LinkTargetID target) : type{type}, target{target} {}
 };
 
 using LeagueTableID = PoolID<uint8_t, struct LeagueTableIDTag, 255, 0xFF>; ///< ID of a league table

--- a/src/linkgraph/linkgraph.h
+++ b/src/linkgraph/linkgraph.h
@@ -40,12 +40,12 @@ public:
 	 * An edge in the link graph. Corresponds to a link between two stations.
 	 */
 	struct BaseEdge {
-		uint capacity;                 ///< Capacity of the link.
-		uint usage;                    ///< Usage of the link.
-		uint64_t travel_time_sum;        ///< Sum of the travel times of the link, in ticks.
-		TimerGameEconomy::Date last_unrestricted_update; ///< When the unrestricted part of the link was last updated.
-		TimerGameEconomy::Date last_restricted_update;   ///< When the restricted part of the link was last updated.
-		NodeID dest_node;              ///< Destination of the edge.
+		uint capacity = 0; ///< Capacity of the link.
+		uint usage = 0; ///< Usage of the link.
+		uint64_t travel_time_sum = 0; ///< Sum of the travel times of the link, in ticks.
+		TimerGameEconomy::Date last_unrestricted_update{}; ///< When the unrestricted part of the link was last updated.
+		TimerGameEconomy::Date last_restricted_update{}; ///< When the restricted part of the link was last updated.
+		NodeID dest_node = INVALID_NODE; ///< Destination of the edge.
 
 		BaseEdge(NodeID dest_node = INVALID_NODE);
 
@@ -88,11 +88,11 @@ public:
 	 * in a separate thread.
 	 */
 	struct BaseNode {
-		uint supply;             ///< Supply at the station.
-		uint demand;             ///< Acceptance at the station.
-		StationID station;       ///< Station ID.
-		TileIndex xy;            ///< Location of the station referred to by the node.
-		TimerGameEconomy::Date last_update;        ///< When the supply was last updated.
+		uint supply = 0; ///< Supply at the station.
+		uint demand = 0; ///< Acceptance at the station.
+		StationID station = StationID::Invalid(); ///< Station ID.
+		TileIndex xy = INVALID_TILE; ///< Location of the station referred to by the node.
+		TimerGameEconomy::Date last_update{}; ///< When the supply was last updated.
 
 		std::vector<BaseEdge> edges; ///< Sorted list of outgoing edges from this node.
 
@@ -189,7 +189,7 @@ public:
 	}
 
 	/** Bare constructor, only for save/load. */
-	LinkGraph() : cargo(INVALID_CARGO), last_compression(0) {}
+	LinkGraph() {}
 	/**
 	 * Real constructor.
 	 * @param cargo Cargo the link graph is about.
@@ -261,9 +261,9 @@ protected:
 	friend class SlLinkgraphEdge;
 	friend class LinkGraphJob;
 
-	CargoType cargo;         ///< Cargo of this component's link graph.
-	TimerGameEconomy::Date last_compression; ///< Last time the capacities and supplies were compressed.
-	NodeVector nodes;      ///< Nodes in the component.
+	CargoType cargo = INVALID_CARGO; ///< Cargo of this component's link graph.
+	TimerGameEconomy::Date last_compression{}; ///< Last time the capacities and supplies were compressed.
+	NodeVector nodes{}; ///< Nodes in the component.
 };
 
 #endif /* LINKGRAPH_H */

--- a/src/linkgraph/linkgraphjob.cpp
+++ b/src/linkgraph/linkgraphjob.cpp
@@ -37,9 +37,7 @@ LinkGraphJob::LinkGraphJob(const LinkGraph &orig) :
 		 * This is on purpose. */
 		link_graph(orig),
 		settings(_settings_game.linkgraph),
-		join_date(TimerGameEconomy::date + (_settings_game.linkgraph.recalc_time / EconomyTime::SECONDS_PER_DAY)),
-		job_completed(false),
-		job_aborted(false)
+		join_date(TimerGameEconomy::date + (_settings_game.linkgraph.recalc_time / EconomyTime::SECONDS_PER_DAY))
 {
 }
 

--- a/src/linkgraph/linkgraphjob.h
+++ b/src/linkgraph/linkgraphjob.h
@@ -32,8 +32,8 @@ public:
 	 * Demand between two nodes.
 	 */
 	struct DemandAnnotation {
-		uint demand;             ///< Transport demand between the nodes.
-		uint unsatisfied_demand; ///< Demand over this edge that hasn't been satisfied yet.
+		uint demand = 0; ///< Transport demand between the nodes.
+		uint unsatisfied_demand = 0; ///< Demand over this edge that hasn't been satisfied yet.
 	};
 
 	/**
@@ -41,10 +41,9 @@ public:
 	 */
 	struct EdgeAnnotation {
 		const LinkGraph::BaseEdge &base; ///< Reference to the edge that is annotated.
+		uint flow = 0; ///< Planned flow over this edge.
 
-		uint flow;               ///< Planned flow over this edge.
-
-		EdgeAnnotation(const LinkGraph::BaseEdge &base) : base(base), flow(0) {}
+		EdgeAnnotation(const LinkGraph::BaseEdge &base) : base(base) {}
 
 		/**
 		 * Get the total flow on the edge.
@@ -80,14 +79,14 @@ public:
 	struct NodeAnnotation {
 		const LinkGraph::BaseNode &base; ///< Reference to the node that is annotated.
 
-		uint undelivered_supply; ///< Amount of supply that hasn't been distributed yet.
-		PathList paths;          ///< Paths through this node, sorted so that those with flow == 0 are in the back.
-		FlowStatMap flows;       ///< Planned flows to other nodes.
+		uint undelivered_supply = 0; ///< Amount of supply that hasn't been distributed yet.
+		PathList paths{}; ///< Paths through this node, sorted so that those with flow == 0 are in the back.
+		FlowStatMap flows{}; ///< Planned flows to other nodes.
 
-		std::vector<EdgeAnnotation>   edges;   ///< Annotations for all edges originating at this node.
-		std::vector<DemandAnnotation> demands; ///< Annotations for the demand to all other nodes.
+		std::vector<EdgeAnnotation> edges{}; ///< Annotations for all edges originating at this node.
+		std::vector<DemandAnnotation> demands{}; ///< Annotations for the demand to all other nodes.
 
-		NodeAnnotation(const LinkGraph::BaseNode &node, size_t size) : base(node), undelivered_supply(node.supply), paths(), flows()
+		NodeAnnotation(const LinkGraph::BaseNode &node, size_t size) : base(node), undelivered_supply(node.supply)
 		{
 			this->edges.reserve(node.edges.size());
 			for (auto &e : node.edges) this->edges.emplace_back(e);
@@ -160,13 +159,13 @@ private:
 	friend class LinkGraphSchedule;
 
 protected:
-	const LinkGraph link_graph;        ///< Link graph to by analyzed. Is copied when job is started and mustn't be modified later.
-	const LinkGraphSettings settings;  ///< Copy of _settings_game.linkgraph at spawn time.
-	std::thread thread;                ///< Thread the job is running in or a default-constructed thread if it's running in the main thread.
-	TimerGameEconomy::Date join_date; ///< Date when the job is to be joined.
-	NodeAnnotationVector nodes;        ///< Extra node data necessary for link graph calculation.
-	std::atomic<bool> job_completed;   ///< Is the job still running. This is accessed by multiple threads and reads may be stale.
-	std::atomic<bool> job_aborted;     ///< Has the job been aborted. This is accessed by multiple threads and reads may be stale.
+	const LinkGraph link_graph; ///< Link graph to by analyzed. Is copied when job is started and mustn't be modified later.
+	const LinkGraphSettings settings; ///< Copy of _settings_game.linkgraph at spawn time.
+	std::thread thread{}; ///< Thread the job is running in or a default-constructed thread if it's running in the main thread.
+	TimerGameEconomy::Date join_date = EconomyTime::INVALID_DATE; ///< Date when the job is to be joined.
+	NodeAnnotationVector nodes{}; ///< Extra node data necessary for link graph calculation.
+	std::atomic<bool> job_completed = false; ///< Is the job still running. This is accessed by multiple threads and reads may be stale.
+	std::atomic<bool> job_aborted = false; ///< Has the job been aborted. This is accessed by multiple threads and reads may be stale.
 
 	void EraseFlows(NodeID from);
 	void JoinThread();
@@ -177,8 +176,7 @@ public:
 	 * Bare constructor, only for save/load. link_graph, join_date and actually
 	 * settings have to be brutally const-casted in order to populate them.
 	 */
-	LinkGraphJob() : settings(_settings_game.linkgraph),
-			join_date(EconomyTime::INVALID_DATE), job_completed(false), job_aborted(false) {}
+	LinkGraphJob() : settings(_settings_game.linkgraph) {}
 
 	LinkGraphJob(const LinkGraph &orig);
 	~LinkGraphJob();
@@ -353,14 +351,14 @@ protected:
 	static constexpr int PATH_CAP_MIN_FREE = (INT_MIN + 1) / PATH_CAP_MULTIPLIER;
 	static constexpr int PATH_CAP_MAX_FREE = (INT_MAX - 1) / PATH_CAP_MULTIPLIER;
 
-	uint distance;     ///< Sum(distance of all legs up to this one).
-	uint capacity;     ///< This capacity is min(capacity) fom all edges.
-	int free_capacity; ///< This capacity is min(edge.capacity - edge.flow) for the current run of Dijkstra.
-	uint flow;         ///< Flow the current run of the mcf solver assigns.
-	NodeID node;       ///< Link graph node this leg passes.
-	NodeID origin;     ///< Link graph node this path originates from.
-	uint num_children; ///< Number of child legs that have been forked from this path.
-	Path *parent;      ///< Parent leg of this one.
+	uint distance = 0; ///< Sum(distance of all legs up to this one).
+	uint capacity = 0; ///< This capacity is min(capacity) fom all edges.
+	int free_capacity = 0; ///< This capacity is min(edge.capacity - edge.flow) for the current run of Dijkstra.
+	uint flow = 0; ///< Flow the current run of the mcf solver assigns.
+	NodeID node = INVALID_NODE; ///< Link graph node this leg passes.
+	NodeID origin = INVALID_NODE; ///< Link graph node this path originates from.
+	uint num_children = 0; ///< Number of child legs that have been forked from this path.
+	Path *parent = nullptr; ///< Parent leg of this one.
 };
 
 #endif /* LINKGRAPHJOB_H */

--- a/src/newgrf.cpp
+++ b/src/newgrf.cpp
@@ -649,8 +649,7 @@ static Engine *GetNewEngine(const GRFFile *file, VehicleType type, uint16_t inte
 		if (engine != EngineID::Invalid()) {
 			Engine *e = Engine::Get(engine);
 			if (!e->grf_prop.HasGrfFile()) {
-				e->grf_prop.grfid = file->grfid;
-				e->grf_prop.grffile = file;
+				e->grf_prop.SetGRFFile(file);
 			}
 			return e;
 		}
@@ -662,8 +661,7 @@ static Engine *GetNewEngine(const GRFFile *file, VehicleType type, uint16_t inte
 		Engine *e = Engine::Get(engine);
 
 		if (!e->grf_prop.HasGrfFile()) {
-			e->grf_prop.grfid = file->grfid;
-			e->grf_prop.grffile = file;
+			e->grf_prop.SetGRFFile(file);
 			GrfMsg(5, "Replaced engine at index {} for GRFID {:x}, type {}, index {}", e->index, std::byteswap(file->grfid), type, internal_id);
 		}
 
@@ -681,8 +679,7 @@ static Engine *GetNewEngine(const GRFFile *file, VehicleType type, uint16_t inte
 
 	/* ... it's not, so create a new one based off an existing engine */
 	Engine *e = new Engine(type, internal_id);
-	e->grf_prop.grfid = file->grfid;
-	e->grf_prop.grffile = file;
+	e->grf_prop.SetGRFFile(file);
 
 	/* Reserve the engine slot */
 	_engine_mngr.SetID(type, internal_id, scope_grfid, std::min<uint8_t>(internal_id, _engine_counts[type]), e->index);
@@ -2559,8 +2556,7 @@ static ChangeInfoResult TownHouseChangeInfo(uint first, uint last, int prop, Byt
 					housespec->enabled = true;
 					housespec->grf_prop.local_id = id;
 					housespec->grf_prop.subst_id = subs_id;
-					housespec->grf_prop.grfid = _cur.grffile->grfid;
-					housespec->grf_prop.grffile = _cur.grffile;
+					housespec->grf_prop.SetGRFFile(_cur.grffile);
 					/* Set default colours for randomization, used if not overridden. */
 					housespec->random_colour[0] = COLOUR_RED;
 					housespec->random_colour[1] = COLOUR_BLUE;
@@ -3472,8 +3468,7 @@ static ChangeInfoResult IndustrytilesChangeInfo(uint first, uint last, int prop,
 
 					tsp->grf_prop.local_id = id;
 					tsp->grf_prop.subst_id = subs_id;
-					tsp->grf_prop.grfid = _cur.grffile->grfid;
-					tsp->grf_prop.grffile = _cur.grffile;
+					tsp->grf_prop.SetGRFFile(_cur.grffile);
 					_industile_mngr.AddEntityID(id, _cur.grffile->grfid, subs_id); // pre-reserve the tile slot
 				}
 				break;
@@ -3738,8 +3733,7 @@ static ChangeInfoResult IndustriesChangeInfo(uint first, uint last, int prop, By
 					indsp->enabled = true;
 					indsp->grf_prop.local_id = id;
 					indsp->grf_prop.subst_id = subs_id;
-					indsp->grf_prop.grfid = _cur.grffile->grfid;
-					indsp->grf_prop.grffile = _cur.grffile;
+					indsp->grf_prop.SetGRFFile(_cur.grffile);
 					/* If the grf industry needs to check its surrounding upon creation, it should
 					 * rely on callbacks, not on the original placement functions */
 					indsp->check_proc = CHECK_NOTHING;
@@ -4116,8 +4110,7 @@ static ChangeInfoResult AirportChangeInfo(uint first, uint last, int prop, ByteR
 					as->enabled = true;
 					as->grf_prop.local_id = id;
 					as->grf_prop.subst_id = subs_id;
-					as->grf_prop.grfid = _cur.grffile->grfid;
-					as->grf_prop.grffile = _cur.grffile;
+					as->grf_prop.SetGRFFile(_cur.grffile);
 					/* override the default airport */
 					_airport_mngr.Add(id, _cur.grffile->grfid, subs_id);
 				}
@@ -4904,8 +4897,7 @@ static ChangeInfoResult AirportTilesChangeInfo(uint first, uint last, int prop, 
 
 					tsp->grf_prop.local_id = id;
 					tsp->grf_prop.subst_id = subs_id;
-					tsp->grf_prop.grfid = _cur.grffile->grfid;
-					tsp->grf_prop.grffile = _cur.grffile;
+					tsp->grf_prop.SetGRFFile(_cur.grffile);
 					_airporttile_mngr.AddEntityID(id, _cur.grffile->grfid, subs_id); // pre-reserve the tile slot
 				}
 				break;
@@ -6018,8 +6010,7 @@ static void StationMapSpriteGroup(ByteReader &buf, uint8_t idcount)
 		}
 
 		statspec->grf_prop.SetSpriteGroup(SpriteGroupCargo::SG_DEFAULT, _cur.spritegroups[groupid]);
-		statspec->grf_prop.grfid = _cur.grffile->grfid;
-		statspec->grf_prop.grffile = _cur.grffile;
+		statspec->grf_prop.SetGRFFile(_cur.grffile);
 		statspec->grf_prop.local_id = station;
 		StationClass::Assign(statspec);
 	}
@@ -6203,8 +6194,7 @@ static void ObjectMapSpriteGroup(ByteReader &buf, uint8_t idcount)
 		}
 
 		spec->grf_prop.SetSpriteGroup(OBJECT_SPRITE_GROUP_DEFAULT, _cur.spritegroups[groupid]);
-		spec->grf_prop.grfid = _cur.grffile->grfid;
-		spec->grf_prop.grffile = _cur.grffile;
+		spec->grf_prop.SetGRFFile(_cur.grffile);
 		spec->grf_prop.local_id = object;
 	}
 }
@@ -6390,8 +6380,7 @@ static void RoadStopMapSpriteGroup(ByteReader &buf, uint8_t idcount)
 		}
 
 		roadstopspec->grf_prop.SetSpriteGroup(SpriteGroupCargo::SG_DEFAULT, _cur.spritegroups[groupid]);
-		roadstopspec->grf_prop.grfid = _cur.grffile->grfid;
-		roadstopspec->grf_prop.grffile = _cur.grffile;
+		roadstopspec->grf_prop.SetGRFFile(_cur.grffile);
 		roadstopspec->grf_prop.local_id = roadstop;
 		RoadStopClass::Assign(roadstopspec);
 	}
@@ -6442,7 +6431,7 @@ static void BadgeMapSpriteGroup(ByteReader &buf, uint8_t idcount)
 
 		auto &badge = *GetBadge(found->second);
 		badge.grf_prop.SetSpriteGroup(GSF_END, _cur.spritegroups[groupid]);
-		badge.grf_prop.grffile = _cur.grffile;
+		badge.grf_prop.SetGRFFile(_cur.grffile);
 		badge.grf_prop.local_id = local_id;
 	}
 }

--- a/src/newgrf_commons.cpp
+++ b/src/newgrf_commons.cpp
@@ -733,6 +733,16 @@ void NewGRFSpriteLayout::ProcessRegisters(uint8_t resolved_var10, uint32_t resol
 }
 
 /**
+ * Set the NewGRF file, and its grfid, associated with grf props.
+ * @param grffile GRFFile to set.
+ */
+void GRFFilePropsBase::SetGRFFile(const struct GRFFile *grffile)
+{
+	this->grffile = grffile;
+	this->grfid = grffile == nullptr ? 0 : grffile->grfid;
+}
+
+/**
  * Get the SpriteGroup at the specified index.
  * @param index Index to get.
  * @returns SpriteGroup at index, or nullptr if not present.

--- a/src/newgrf_commons.h
+++ b/src/newgrf_commons.h
@@ -294,6 +294,8 @@ struct GRFFilePropsBase {
 	uint32_t grfid = 0; ///< grfid that introduced this entity.
 	const struct GRFFile *grffile = nullptr; ///< grf file that introduced this entity
 
+	void SetGRFFile(const struct GRFFile *grffile);
+
 	/**
 	 * Test if this entity was introduced by NewGRF.
 	 * @returns true iff the grfid property is set.

--- a/src/newgrf_engine.cpp
+++ b/src/newgrf_engine.cpp
@@ -71,8 +71,7 @@ void SetCustomEngineSprites(EngineID engine, CargoType cargo, const SpriteGroup 
 void SetEngineGRF(EngineID engine, const GRFFile *file)
 {
 	Engine *e = Engine::Get(engine);
-	e->grf_prop.grfid = file->grfid;
-	e->grf_prop.grffile = file;
+	e->grf_prop.SetGRFFile(file);
 }
 
 

--- a/src/object_base.h
+++ b/src/object_base.h
@@ -21,15 +21,17 @@ extern ObjectPool _object_pool;
 
 /** An object, such as transmitter, on the map. */
 struct Object : ObjectPool::PoolItem<&_object_pool> {
-	ObjectType type;    ///< Type of the object
-	Town *town;         ///< Town the object is built in
-	TileArea location;  ///< Location of the object
-	TimerGameCalendar::Date build_date; ///< Date of construction
-	uint8_t colour;        ///< Colour of the object, for display purpose
-	uint8_t view;          ///< The view setting for this object
+	ObjectType type = INVALID_OBJECT_TYPE; ///< Type of the object
+	Town *town = nullptr; ///< Town the object is built in
+	TileArea location{INVALID_TILE, 0, 0}; ///< Location of the object
+	TimerGameCalendar::Date build_date{}; ///< Date of construction
+	uint8_t colour = 0; ///< Colour of the object, for display purpose
+	uint8_t view = 0; ///< The view setting for this object
 
 	/** Make sure the object isn't zeroed. */
 	Object() {}
+	Object(ObjectType type, Town *town, TileArea location, TimerGameCalendar::Date build_date, uint8_t view) :
+		type(type), town(town), location(location), build_date(build_date), view(view) {}
 	/** Make sure the right destructor is called as well! */
 	~Object() {}
 

--- a/src/object_cmd.cpp
+++ b/src/object_cmd.cpp
@@ -90,12 +90,7 @@ void BuildObject(ObjectType type, TileIndex tile, CompanyID owner, Town *town, u
 	const ObjectSpec *spec = ObjectSpec::Get(type);
 
 	TileArea ta(tile, GB(spec->size, HasBit(view, 0) ? 4 : 0, 4), GB(spec->size, HasBit(view, 0) ? 0 : 4, 4));
-	Object *o = new Object();
-	o->type          = type;
-	o->location      = ta;
-	o->town          = town == nullptr ? CalcClosestTownFromTile(tile) : town;
-	o->build_date    = TimerGameCalendar::date;
-	o->view          = view;
+	Object *o = new Object(type, town == nullptr ? CalcClosestTownFromTile(tile) : town, ta, TimerGameCalendar::date, view);
 
 	/* If nothing owns the object, the colour will be random. Otherwise
 	 * get the colour from the company's livery settings. */

--- a/src/order_backup.cpp
+++ b/src/order_backup.cpp
@@ -43,12 +43,8 @@ OrderBackup::~OrderBackup()
  * @param v    The vehicle to make a backup of.
  * @param user The user that is requesting the backup.
  */
-OrderBackup::OrderBackup(const Vehicle *v, uint32_t user)
+OrderBackup::OrderBackup(const Vehicle *v, uint32_t user) : user(user), tile(v->tile), group(v->group_id)
 {
-	this->user             = user;
-	this->tile             = v->tile;
-	this->group            = v->group_id;
-
 	this->CopyConsistPropertiesFrom(v);
 
 	/* If we have shared orders, store the vehicle we share the order with. */

--- a/src/order_backup.h
+++ b/src/order_backup.h
@@ -34,12 +34,12 @@ struct OrderBackup : OrderBackupPool::PoolItem<&_order_backup_pool>, BaseConsist
 private:
 	friend SaveLoadTable GetOrderBackupDescription(); ///< Saving and loading of order backups.
 	friend struct BKORChunkHandler; ///< Creating empty orders upon savegame loading.
-	uint32_t user;               ///< The user that requested the backup.
-	TileIndex tile;            ///< Tile of the depot where the order was changed.
-	GroupID group;             ///< The group the vehicle was part of.
+	uint32_t user = 0; ///< The user that requested the backup.
+	TileIndex tile = INVALID_TILE; ///< Tile of the depot where the order was changed.
+	GroupID group = GroupID::Invalid(); ///< The group the vehicle was part of.
 
-	const Vehicle *clone;      ///< Vehicle this vehicle was a clone of.
-	Order *orders;             ///< The actual orders if the vehicle was not a clone.
+	const Vehicle *clone = nullptr; ///< Vehicle this vehicle was a clone of.
+	Order *orders = nullptr; ///< The actual orders if the vehicle was not a clone.
 
 	/** Creation for savegame restoration. */
 	OrderBackup() {}

--- a/src/order_base.h
+++ b/src/order_base.h
@@ -260,20 +260,18 @@ private:
 	friend void AfterLoadVehiclesPhase1(bool part_of_load); ///< For instantiating the shared vehicle chain
 	friend SaveLoadTable GetOrderListDescription(); ///< Saving and loading of order lists.
 
-	VehicleOrderID num_orders;        ///< NOSAVE: How many orders there are in the list.
-	VehicleOrderID num_manual_orders; ///< NOSAVE: How many manually added orders are there in the list.
-	uint num_vehicles;                ///< NOSAVE: Number of vehicles that share this order list.
-	Vehicle *first_shared;            ///< NOSAVE: pointer to the first vehicle in the shared order chain.
-	Order *first;                     ///< First order of the order list.
+	VehicleOrderID num_orders = INVALID_VEH_ORDER_ID; ///< NOSAVE: How many orders there are in the list.
+	VehicleOrderID num_manual_orders = 0; ///< NOSAVE: How many manually added orders are there in the list.
+	uint num_vehicles = 0; ///< NOSAVE: Number of vehicles that share this order list.
+	Vehicle *first_shared = nullptr; ///< NOSAVE: pointer to the first vehicle in the shared order chain.
+	Order *first = nullptr; ///< First order of the order list.
 
-	TimerGameTick::Ticks timetable_duration;         ///< NOSAVE: Total timetabled duration of the order list.
-	TimerGameTick::Ticks total_duration;             ///< NOSAVE: Total (timetabled or not) duration of the order list.
+	TimerGameTick::Ticks timetable_duration{}; ///< NOSAVE: Total timetabled duration of the order list.
+	TimerGameTick::Ticks total_duration{}; ///< NOSAVE: Total (timetabled or not) duration of the order list.
 
 public:
 	/** Default constructor producing an invalid order list. */
-	OrderList(VehicleOrderID num_orders = INVALID_VEH_ORDER_ID)
-		: num_orders(num_orders), num_manual_orders(0), num_vehicles(0), first_shared(nullptr), first(nullptr),
-		  timetable_duration(0), total_duration(0) { }
+	OrderList(VehicleOrderID num_orders = INVALID_VEH_ORDER_ID) : num_orders(num_orders) { }
 
 	/**
 	 * Create an order list with the given order chain for the given vehicle.

--- a/src/roadstop_base.h
+++ b/src/roadstop_base.h
@@ -32,14 +32,14 @@ struct RoadStop : RoadStopPool::PoolItem<&_roadstop_pool> {
 	/** Container for each entry point of a drive through road stop */
 	struct Entry {
 	private:
-		int length;      ///< The length of the stop in tile 'units'
-		int occupied;    ///< The amount of occupied stop in tile 'units'
+		int length = 0; ///< The length of the stop in tile 'units'
+		int occupied = 0; ///< The amount of occupied stop in tile 'units'
 
 	public:
 		friend struct RoadStop; ///< Oh yeah, the road stop may play with me.
 
 		/** Create an entry */
-		Entry() : length(0), occupied(0) {}
+		Entry() {}
 
 		/**
 		 * Get the length of this drive through stop.
@@ -65,9 +65,9 @@ struct RoadStop : RoadStopPool::PoolItem<&_roadstop_pool> {
 		void Rebuild(const RoadStop *rs, int side = -1);
 	};
 
-	uint8_t status; ///< Current status of the Stop, @see RoadStopSatusFlag. Access using *Bay and *Busy functions.
-	TileIndex xy; ///< Position on the map
-	RoadStop *next; ///< Next stop of the given type at this station
+	uint8_t status = 0; ///< Current status of the Stop, @see RoadStopSatusFlag. Access using *Bay and *Busy functions.
+	TileIndex xy = INVALID_TILE; ///< Position on the map
+	RoadStop *next = nullptr; ///< Next stop of the given type at this station
 
 	/** Initializes a RoadStop */
 	inline RoadStop(TileIndex tile = INVALID_TILE) :
@@ -148,8 +148,8 @@ struct RoadStop : RoadStopPool::PoolItem<&_roadstop_pool> {
 	static bool IsDriveThroughRoadStopContinuation(TileIndex rs, TileIndex next);
 
 private:
-	Entry *east; ///< The vehicles that entered from the east
-	Entry *west; ///< The vehicles that entered from the west
+	Entry *east = nullptr; ///< The vehicles that entered from the east
+	Entry *west = nullptr; ///< The vehicles that entered from the west
 
 	/**
 	 * Allocates a bay

--- a/src/roadveh.h
+++ b/src/roadveh.h
@@ -83,10 +83,10 @@ void GetRoadVehSpriteSize(EngineID engine, uint &width, uint &height, int &xoffs
 
 /** Element of the RoadVehPathCache. */
 struct RoadVehPathElement {
-	Trackdir trackdir; ///< Trackdir for this element.
-	TileIndex tile; ///< Tile for this element.
+	Trackdir trackdir = INVALID_TRACKDIR; ///< Trackdir for this element.
+	TileIndex tile = INVALID_TILE; ///< Tile for this element.
 
-	constexpr RoadVehPathElement() : trackdir(INVALID_TRACKDIR), tile(INVALID_TILE) {}
+	constexpr RoadVehPathElement() {}
 	constexpr RoadVehPathElement(Trackdir trackdir, TileIndex tile) : trackdir(trackdir), tile(tile) {}
 };
 
@@ -96,18 +96,18 @@ using RoadVehPathCache = std::vector<RoadVehPathElement>;
  * Buses, trucks and trams belong to this class.
  */
 struct RoadVehicle final : public GroundVehicle<RoadVehicle, VEH_ROAD> {
-	RoadVehPathCache path;  ///< Cached path.
-	uint8_t state;             ///< @see RoadVehicleStates
-	uint8_t frame;
-	uint16_t blocked_ctr;
-	uint8_t overtaking;        ///< Set to #RVSB_DRIVE_SIDE when overtaking, otherwise 0.
-	uint8_t overtaking_ctr;    ///< The length of the current overtake attempt.
-	uint16_t crashed_ctr;     ///< Animation counter when the vehicle has crashed. @see RoadVehIsCrashed
-	uint8_t reverse_ctr;
+	RoadVehPathCache path{};  ///< Cached path.
+	uint8_t state = 0; ///< @see RoadVehicleStates
+	uint8_t frame = 0;
+	uint16_t blocked_ctr = 0;
+	uint8_t overtaking = 0; ///< Set to #RVSB_DRIVE_SIDE when overtaking, otherwise 0.
+	uint8_t overtaking_ctr = 0; ///< The length of the current overtake attempt.
+	uint16_t crashed_ctr = 0; ///< Animation counter when the vehicle has crashed. @see RoadVehIsCrashed
+	uint8_t reverse_ctr = 0;
 
-	RoadType roadtype; ///< NOSAVE: Roadtype of this vehicle.
+	RoadType roadtype = INVALID_ROADTYPE; ///< NOSAVE: Roadtype of this vehicle.
 	VehicleID disaster_vehicle = VehicleID::Invalid(); ///< NOSAVE: Disaster vehicle targetting this vehicle.
-	RoadTypes compatible_roadtypes; ///< NOSAVE: Roadtypes this consist is powered on.
+	RoadTypes compatible_roadtypes{}; ///< NOSAVE: Roadtypes this consist is powered on.
 
 	/** We don't want GCC to zero our struct! It already is zeroed and has an index! */
 	RoadVehicle() : GroundVehicleBase() {}

--- a/src/saveload/afterload.cpp
+++ b/src/saveload/afterload.cpp
@@ -2486,6 +2486,12 @@ bool AfterLoadGame()
 		for (Depot *d : Depot::Iterate()) d->build_date = TimerGameCalendar::date;
 	}
 
+	if (IsSavegameVersionBefore(SLV_145)) {
+		for (Station *st : Station::Iterate()) {
+			if (st->facilities.Test(StationFacility::Airport)) st->airport.rotation = DIR_N;
+		}
+	}
+
 	/* In old versions it was possible to remove an airport while a plane was
 	 * taking off or landing. This gives all kind of problems when building
 	 * another airport in the same station so we don't allow that anymore.

--- a/src/script/api/ai/ai_controller.hpp.sq
+++ b/src/script/api/ai/ai_controller.hpp.sq
@@ -7,12 +7,14 @@
 
 #include "../script_controller.hpp"
 
-template <> const char *GetClassName<ScriptController, ScriptType::AI>() { return "AIController"; }
+template <> SQInteger PushClassName<ScriptController, ScriptType::AI>(HSQUIRRELVM vm) { sq_pushstring(vm, "AIController", -1); return 1; }
 
 void SQAIController_Register(Squirrel *engine)
 {
 	DefSQClass<ScriptController, ScriptType::AI> SQAIController("AIController");
 	SQAIController.PreRegister(engine);
+
+	SQAIController.DefSQAdvancedStaticMethod(engine, &PushClassName<ScriptController, ScriptType::AI>, "_typeof");
 
 	SQAIController.DefSQStaticMethod(engine, &ScriptController::GetTick,           "GetTick",           1, ".");
 	SQAIController.DefSQStaticMethod(engine, &ScriptController::GetOpsTillSuspend, "GetOpsTillSuspend", 1, ".");

--- a/src/script/api/game/game_controller.hpp.sq
+++ b/src/script/api/game/game_controller.hpp.sq
@@ -7,12 +7,14 @@
 
 #include "../script_controller.hpp"
 
-template <> const char *GetClassName<ScriptController, ScriptType::GS>() { return "GSController"; }
+template <> SQInteger PushClassName<ScriptController, ScriptType::GS>(HSQUIRRELVM vm) { sq_pushstring(vm, "GSController", -1); return 1; }
 
 void SQGSController_Register(Squirrel *engine)
 {
 	DefSQClass<ScriptController, ScriptType::GS> SQGSController("GSController");
 	SQGSController.PreRegister(engine);
+
+	SQGSController.DefSQAdvancedStaticMethod(engine, &PushClassName<ScriptController, ScriptType::GS>, "_typeof");
 
 	SQGSController.DefSQStaticMethod(engine, &ScriptController::GetTick,           "GetTick",           1, ".");
 	SQGSController.DefSQStaticMethod(engine, &ScriptController::GetOpsTillSuspend, "GetOpsTillSuspend", 1, ".");

--- a/src/script/squirrel_helper.hpp
+++ b/src/script/squirrel_helper.hpp
@@ -16,7 +16,7 @@
 #include "../core/convertible_through_base.hpp"
 #include "squirrel_helper_type.hpp"
 
-template <class CL, ScriptType ST> const char *GetClassName();
+template <class CL, ScriptType ST> SQInteger PushClassName(HSQUIRRELVM);
 
 /**
  * The Squirrel convert routines
@@ -240,8 +240,7 @@ namespace SQConvert {
 
 		/* Protect against calls to a non-static method in a static way */
 		sq_pushroottable(vm);
-		const char *className = GetClassName<Tcls, Ttype>();
-		sq_pushstring(vm, className, -1);
+		PushClassName<Tcls, Ttype>(vm);
 		sq_get(vm, -2);
 		sq_pushobject(vm, instance);
 		if (sq_instanceof(vm) != SQTrue) return sq_throwerror(vm, "class method is non-static");
@@ -284,8 +283,7 @@ namespace SQConvert {
 
 		/* Protect against calls to a non-static method in a static way */
 		sq_pushroottable(vm);
-		const char *className = GetClassName<Tcls, Ttype>();
-		sq_pushstring(vm, className, -1);
+		PushClassName<Tcls, Ttype>(vm);
 		sq_get(vm, -2);
 		sq_pushobject(vm, instance);
 		if (sq_instanceof(vm) != SQTrue) return sq_throwerror(vm, "class method is non-static");

--- a/src/ship.h
+++ b/src/ship.h
@@ -18,9 +18,9 @@ WaterClass GetEffectiveWaterClass(TileIndex tile);
 
 /** Element of the ShipPathCache. */
 struct ShipPathElement {
-	Trackdir trackdir; ///< Trackdir for this element.
+	Trackdir trackdir = INVALID_TRACKDIR; ///< Trackdir for this element.
 
-	constexpr ShipPathElement() : trackdir(INVALID_TRACKDIR) {}
+	constexpr ShipPathElement() {}
 	constexpr ShipPathElement(Trackdir trackdir) : trackdir(trackdir) {}
 };
 
@@ -30,11 +30,11 @@ using ShipPathCache = std::vector<ShipPathElement>;
  * All ships have this type.
  */
 struct Ship final : public SpecializedVehicle<Ship, VEH_SHIP> {
-	ShipPathCache path;   ///< Cached path.
-	TrackBits state;      ///< The "track" the ship is following.
-	Direction rotation;   ///< Visible direction.
-	int16_t rotation_x_pos; ///< NOSAVE: X Position before rotation.
-	int16_t rotation_y_pos; ///< NOSAVE: Y Position before rotation.
+	ShipPathCache path{}; ///< Cached path.
+	TrackBits state{}; ///< The "track" the ship is following.
+	Direction rotation = INVALID_DIR; ///< Visible direction.
+	int16_t rotation_x_pos = 0; ///< NOSAVE: X Position before rotation.
+	int16_t rotation_y_pos = 0; ///< NOSAVE: Y Position before rotation.
 
 	/** We don't want GCC to zero our struct! It already is zeroed and has an index! */
 	Ship() : SpecializedVehicleBase() {}

--- a/src/signs.cpp
+++ b/src/signs.cpp
@@ -24,14 +24,6 @@
 SignPool _sign_pool("Sign");
 INSTANTIATE_POOL_METHODS(Sign)
 
-/**
- * Creates a new sign
- */
-Sign::Sign(Owner owner)
-{
-	this->owner = owner;
-}
-
 /** Destroy the sign */
 Sign::~Sign()
 {

--- a/src/signs_base.h
+++ b/src/signs_base.h
@@ -19,14 +19,15 @@ typedef Pool<Sign, SignID, 16> SignPool;
 extern SignPool _sign_pool;
 
 struct Sign : SignPool::PoolItem<&_sign_pool> {
-	std::string         name;
-	TrackedViewportSign sign;
-	int32_t               x;
-	int32_t               y;
-	int32_t               z;
-	Owner               owner; // placed by this company. Anyone can delete them though. OWNER_NONE for gray signs from old games.
+	std::string name{};
+	TrackedViewportSign sign{};
+	int32_t x = 0;
+	int32_t y = 0;
+	int32_t z = 0;
+	Owner owner = INVALID_OWNER; // placed by this company. Anyone can delete them though. OWNER_NONE for gray signs from old games.
 
-	Sign(Owner owner = INVALID_OWNER);
+	Sign() {}
+	Sign(Owner owner, int32_t x, int32_t y, int32_t z, const std::string &name) : name(name), x(x), y(y), z(z), owner(owner) {}
 	~Sign();
 
 	void UpdateVirtCoord();

--- a/src/signs_cmd.cpp
+++ b/src/signs_cmd.cpp
@@ -42,16 +42,11 @@ std::tuple<CommandCost, SignID> CmdPlaceSign(DoCommandFlags flags, TileIndex til
 
 	/* When we execute, really make the sign */
 	if (flags.Test(DoCommandFlag::Execute)) {
-		Sign *si = new Sign(_game_mode == GM_EDITOR ? OWNER_DEITY : _current_company);
 		int x = TileX(tile) * TILE_SIZE;
 		int y = TileY(tile) * TILE_SIZE;
 
-		si->x = x;
-		si->y = y;
-		si->z = GetSlopePixelZ(x, y);
-		if (!text.empty()) {
-			si->name = text;
-		}
+		Sign *si = new Sign(_game_mode == GM_EDITOR ? OWNER_DEITY : _current_company, x, y, GetSlopePixelZ(x, y), text);
+
 		si->UpdateVirtCoord();
 		InvalidateWindowData(WC_SIGN_LIST, 0, 0);
 		return { CommandCost(), si->index };

--- a/src/station_base.h
+++ b/src/station_base.h
@@ -140,8 +140,8 @@ public:
 	void Invalidate();
 
 private:
-	SharesMap shares;  ///< Shares of flow to be sent via specified station (or consumed locally).
-	uint unrestricted; ///< Limit for unrestricted shares.
+	SharesMap shares{}; ///< Shares of flow to be sent via specified station (or consumed locally).
+	uint unrestricted = 0; ///< Limit for unrestricted shares.
 };
 
 /** Flow descriptions by origin stations. */
@@ -347,12 +347,12 @@ private:
 struct Airport : public TileArea {
 	Airport() : TileArea(INVALID_TILE, 0, 0) {}
 
-	AirportBlocks blocks; ///< stores which blocks on the airport are taken. was 16 bit earlier on, then 32
-	uint8_t type;          ///< Type of this airport, @see AirportTypes
-	uint8_t layout;        ///< Airport layout number.
-	Direction rotation; ///< How this airport is rotated.
+	AirportBlocks blocks{}; ///< stores which blocks on the airport are taken. was 16 bit earlier on, then 32
+	uint8_t type = 0; ///< Type of this airport, @see AirportTypes
+	uint8_t layout = 0; ///< Airport layout number.
+	Direction rotation = INVALID_DIR; ///< How this airport is rotated.
 
-	PersistentStorage *psa; ///< Persistent storage for NewGRF airports.
+	PersistentStorage *psa = nullptr; ///< Persistent storage for NewGRF airports.
 
 	/**
 	 * Get the AirportSpec that from the airport type of this airport. If there
@@ -480,8 +480,8 @@ private:
 };
 
 struct IndustryListEntry {
-	uint distance;
-	Industry *industry;
+	uint distance = 0;
+	Industry *industry = nullptr;
 
 	bool operator== (const IndustryListEntry &other) const { return this->distance == other.distance && this->industry == other.industry; };
 };
@@ -502,31 +502,31 @@ public:
 
 	RoadStop *GetPrimaryRoadStop(const struct RoadVehicle *v) const;
 
-	RoadStop *bus_stops;    ///< All the road stops
-	TileArea bus_station;   ///< Tile area the bus 'station' part covers
-	RoadStop *truck_stops;  ///< All the truck stops
-	TileArea truck_station; ///< Tile area the truck 'station' part covers
+	RoadStop *bus_stops = nullptr; ///< All the road stops
+	TileArea bus_station{}; ///< Tile area the bus 'station' part covers
+	RoadStop *truck_stops = nullptr; ///< All the truck stops
+	TileArea truck_station{}; ///< Tile area the truck 'station' part covers
 
-	Airport airport;          ///< Tile area the airport covers
-	TileArea ship_station;    ///< Tile area the ship 'station' part covers
-	TileArea docking_station; ///< Tile area the docking tiles cover
+	Airport airport{}; ///< Tile area the airport covers
+	TileArea ship_station{}; ///< Tile area the ship 'station' part covers
+	TileArea docking_station{}; ///< Tile area the docking tiles cover
 
-	IndustryType indtype;   ///< Industry type to get the name from
+	IndustryType indtype = IT_INVALID; ///< Industry type to get the name from
 
-	BitmapTileArea catchment_tiles; ///< NOSAVE: Set of individual tiles covered by catchment area
+	BitmapTileArea catchment_tiles{}; ///< NOSAVE: Set of individual tiles covered by catchment area
 
-	StationHadVehicleOfType had_vehicle_of_type;
+	StationHadVehicleOfType had_vehicle_of_type{};
 
-	uint8_t time_since_load;
-	uint8_t time_since_unload;
+	uint8_t time_since_load = 0;
+	uint8_t time_since_unload = 0;
 
-	uint8_t last_vehicle_type;
-	std::list<Vehicle *> loading_vehicles;
-	GoodsEntry goods[NUM_CARGO];  ///< Goods at this station
-	CargoTypes always_accepted;       ///< Bitmask of always accepted cargo types (by houses, HQs, industry tiles when industry doesn't accept cargo)
+	uint8_t last_vehicle_type = 0;
+	std::list<Vehicle *> loading_vehicles{};
+	std::array<GoodsEntry, NUM_CARGO> goods; ///< Goods at this station
+	CargoTypes always_accepted{}; ///< Bitmask of always accepted cargo types (by houses, HQs, industry tiles when industry doesn't accept cargo)
 
-	IndustryList industries_near; ///< Cached list of industries near the station that can accept cargo, @see DeliverGoodsToIndustry()
-	Industry *industry;           ///< NOSAVE: Associated industry for neutral stations. (Rebuilt on load from Industry->st)
+	IndustryList industries_near{}; ///< Cached list of industries near the station that can accept cargo, @see DeliverGoodsToIndustry()
+	Industry *industry = nullptr; ///< NOSAVE: Associated industry for neutral stations. (Rebuilt on load from Industry->st)
 
 	Station(TileIndex tile = INVALID_TILE);
 	~Station();
@@ -581,7 +581,7 @@ public:
 /** Iterator to iterate over all tiles belonging to an airport. */
 class AirportTileIterator : public OrthogonalTileIterator {
 private:
-	const Station *st; ///< The station the airport is a part of.
+	const Station *st = nullptr; ///< The station the airport is a part of.
 
 public:
 	/**

--- a/src/story.cpp
+++ b/src/story.cpp
@@ -37,6 +37,15 @@ StoryPagePool _story_page_pool("StoryPage");
 INSTANTIATE_POOL_METHODS(StoryPageElement)
 INSTANTIATE_POOL_METHODS(StoryPage)
 
+StoryPage::~StoryPage()
+{
+	if (!this->CleaningPool()) {
+		for (StoryPageElement *spe : StoryPageElement::Iterate()) {
+			if (spe->page == this->index) delete spe;
+		}
+	}
+}
+
 /**
  * This helper for Create/Update PageElement Cmd procedure verifies if the page
  * element parameters are correct for the given page element type.
@@ -219,11 +228,7 @@ std::tuple<CommandCost, StoryPageID> CmdCreateStoryPage(DoCommandFlags flags, Co
 			_story_page_next_sort_value = 0;
 		}
 
-		StoryPage *s = new StoryPage();
-		s->sort_value = _story_page_next_sort_value;
-		s->date = TimerGameCalendar::date;
-		s->company = company;
-		s->title = text;
+		StoryPage *s = new StoryPage(_story_page_next_sort_value, TimerGameCalendar::date, company, text);
 
 		InvalidateWindowClassesData(WC_STORY_BOOK, -1);
 		if (StoryPage::GetNumItems() == 1) InvalidateWindowData(WC_MAIN_TOOLBAR, 0);
@@ -267,10 +272,7 @@ std::tuple<CommandCost, StoryPageElementID> CmdCreateStoryPageElement(DoCommandF
 			_story_page_element_next_sort_value = 0;
 		}
 
-		StoryPageElement *pe = new StoryPageElement();
-		pe->sort_value = _story_page_element_next_sort_value;
-		pe->type = type;
-		pe->page = page_id;
+		StoryPageElement *pe = new StoryPageElement(_story_page_element_next_sort_value, type, page_id);
 		UpdateElement(*pe, tile, reference, text);
 
 		InvalidateWindowClassesData(WC_STORY_BOOK, page_id);

--- a/src/story_base.h
+++ b/src/story_base.h
@@ -120,7 +120,7 @@ inline bool IsValidStoryPageButtonCursor(StoryPageButtonCursor cursor)
 
 /** Helper to construct packed "id" values for button-type StoryPageElement */
 struct StoryPageButtonData {
-	uint32_t referenced_id;
+	uint32_t referenced_id = 0;
 
 	void SetColour(Colours button_colour);
 	void SetFlags(StoryPageButtonFlags flags);
@@ -152,38 +152,32 @@ struct StoryPageElement : StoryPageElementPool::PoolItem<&_story_page_element_po
 	/**
 	 * We need an (empty) constructor so struct isn't zeroed (as C++ standard states)
 	 */
-	inline StoryPageElement() { }
+	StoryPageElement() { }
+	StoryPageElement(uint32_t sort_value, StoryPageElementType type, StoryPageID page) :
+		sort_value(sort_value), page(page), type(type) { }
 
 	/**
 	 * (Empty) destructor has to be defined else operator delete might be called with nullptr parameter
 	 */
-	inline ~StoryPageElement() { }
+	~StoryPageElement() { }
 };
 
 /** Struct about stories, current and completed */
 struct StoryPage : StoryPagePool::PoolItem<&_story_page_pool> {
-	uint32_t sort_value;            ///< A number that increases for every created story page. Used for sorting. The id of a story page is the pool index.
-	TimerGameCalendar::Date date; ///< Date when the page was created.
-	CompanyID company;            ///< StoryPage is for a specific company; CompanyID::Invalid() if it is global
+	uint32_t sort_value = 0; ///< A number that increases for every created story page. Used for sorting. The id of a story page is the pool index.
+	TimerGameCalendar::Date date{}; ///< Date when the page was created.
+	CompanyID company = CompanyID::Invalid(); ///< StoryPage is for a specific company; CompanyID::Invalid() if it is global
 
-	std::string title;            ///< Title of story page
+	std::string title; ///< Title of story page
 
 	/**
 	 * We need an (empty) constructor so struct isn't zeroed (as C++ standard states)
 	 */
-	inline StoryPage() { }
+	StoryPage() { }
+	StoryPage(uint32_t sort_value, TimerGameCalendar::Date date, CompanyID company, const std::string &title) :
+		sort_value(sort_value), date(date), company(company), title(title) {}
 
-	/**
-	 * (Empty) destructor has to be defined else operator delete might be called with nullptr parameter
-	 */
-	inline ~StoryPage()
-	{
-		if (!this->CleaningPool()) {
-			for (StoryPageElement *spe : StoryPageElement::Iterate()) {
-				if (spe->page == this->index) delete spe;
-			}
-		}
-	}
+	~StoryPage();
 };
 
 #endif /* STORY_BASE_H */

--- a/src/subsidy.cpp
+++ b/src/subsidy.cpp
@@ -201,12 +201,7 @@ static bool CheckSubsidyDistance(Source src, Source dst)
  */
 void CreateSubsidy(CargoType cargo_type, Source src, Source dst)
 {
-	Subsidy *s = new Subsidy();
-	s->cargo_type = cargo_type;
-	s->src = src;
-	s->dst = dst;
-	s->remaining = SUBSIDY_OFFER_MONTHS;
-	s->awarded = CompanyID::Invalid();
+	Subsidy *s = new Subsidy(cargo_type, src, dst, SUBSIDY_OFFER_MONTHS);
 
 	std::pair<NewsReference, NewsReference> references = SetupSubsidyDecodeParam(s, SubsidyDecodeParamType::NewsOffered);
 	AddNewsItem(STR_NEWS_SERVICE_SUBSIDY_OFFERED, NewsType::Subsidies, NewsStyle::Normal, {}, references.first, references.second);

--- a/src/subsidy_base.h
+++ b/src/subsidy_base.h
@@ -21,21 +21,22 @@ extern SubsidyPool _subsidy_pool;
 
 /** Struct about subsidies, offered and awarded */
 struct Subsidy : SubsidyPool::PoolItem<&_subsidy_pool> {
-	CargoType cargo_type;  ///< Cargo type involved in this subsidy, INVALID_CARGO for invalid subsidy
-	uint16_t remaining;    ///< Remaining months when this subsidy is valid
-	CompanyID awarded;   ///< Subsidy is awarded to this company; CompanyID::Invalid() if it's not awarded to anyone
-	Source src; ///< Source of subsidised path
-	Source dst; ///< Destination of subsidised path
+	CargoType cargo_type = INVALID_CARGO;  ///< Cargo type involved in this subsidy, INVALID_CARGO for invalid subsidy
+	uint16_t remaining = 0;    ///< Remaining months when this subsidy is valid
+	CompanyID awarded = CompanyID::Invalid();   ///< Subsidy is awarded to this company; CompanyID::Invalid() if it's not awarded to anyone
+	Source src{}; ///< Source of subsidised path
+	Source dst{}; ///< Destination of subsidised path
 
 	/**
 	 * We need an (empty) constructor so struct isn't zeroed (as C++ standard states)
 	 */
-	inline Subsidy() { }
+	Subsidy() { }
+	Subsidy(CargoType cargo_type, Source src, Source dst, uint16_t remaining) : cargo_type(cargo_type), remaining(remaining), src(src), dst(dst) {}
 
 	/**
 	 * (Empty) destructor has to be defined else operator delete might be called with nullptr parameter
 	 */
-	inline ~Subsidy() { }
+	~Subsidy() { }
 
 	/**
 	 * Tests whether this subsidy has been awarded to someone

--- a/src/town.h
+++ b/src/town.h
@@ -19,8 +19,8 @@
 
 template <typename T>
 struct BuildingCounts {
-	std::vector<T> id_count;
-	std::vector<T> class_count;
+	std::vector<T> id_count{};
+	std::vector<T> class_count{};
 
 	auto operator<=>(const BuildingCounts &) const = default;
 };
@@ -38,47 +38,47 @@ extern TownPool _town_pool;
 
 /** Data structure with cached data of towns. */
 struct TownCache {
-	uint32_t num_houses;                        ///< Amount of houses
-	uint32_t population;                        ///< Current population of people
-	TrackedViewportSign sign;                 ///< Location of name sign, UpdateVirtCoord updates this
-	PartOfSubsidy part_of_subsidy;            ///< Is this town a source/destination of a subsidy?
-	std::array<uint32_t, HZB_END> squared_town_zone_radius; ///< UpdateTownRadius updates this given the house count
-	BuildingCounts<uint16_t> building_counts;   ///< The number of each type of building in the town
+	uint32_t num_houses = 0; ///< Amount of houses
+	uint32_t population = 0; ///< Current population of people
+	TrackedViewportSign sign{}; ///< Location of name sign, UpdateVirtCoord updates this
+	PartOfSubsidy part_of_subsidy{}; ///< Is this town a source/destination of a subsidy?
+	std::array<uint32_t, HZB_END> squared_town_zone_radius{}; ///< UpdateTownRadius updates this given the house count
+	BuildingCounts<uint16_t> building_counts{}; ///< The number of each type of building in the town
 
 	auto operator<=>(const TownCache &) const = default;
 };
 
 /** Town data structure. */
 struct Town : TownPool::PoolItem<&_town_pool> {
-	TileIndex xy;                  ///< town center tile
+	TileIndex xy = INVALID_TILE; ///< town center tile
 
-	TownCache cache; ///< Container for all cacheable data.
+	TownCache cache{}; ///< Container for all cacheable data.
 
 	/* Town name */
-	uint32_t townnamegrfid;
-	uint16_t townnametype;
-	uint32_t townnameparts;
-	std::string name;                ///< Custom town name. If empty, the town was not renamed and uses the generated name.
-	mutable std::string cached_name; ///< NOSAVE: Cache of the resolved name of the town, if not using a custom town name
+	uint32_t townnamegrfid = 0;
+	uint16_t townnametype = 0;
+	uint32_t townnameparts = 0;
+	std::string name{}; ///< Custom town name. If empty, the town was not renamed and uses the generated name.
+	mutable std::string cached_name{}; ///< NOSAVE: Cache of the resolved name of the town, if not using a custom town name
 
-	uint8_t flags;                    ///< See #TownFlags.
+	uint8_t flags = 0; ///< See #TownFlags.
 
-	uint16_t noise_reached;          ///< level of noise that all the airports are generating
+	uint16_t noise_reached = 0; ///< level of noise that all the airports are generating
 
-	CompanyMask statues;           ///< which companies have a statue?
+	CompanyMask statues{}; ///< which companies have a statue?
 
 	/* Company ratings. */
-	CompanyMask have_ratings;      ///< which companies have a rating
-	ReferenceThroughBaseContainer<std::array<uint8_t, MAX_COMPANIES>> unwanted; ///< how many months companies aren't wanted by towns (bribe)
-	CompanyID exclusivity;         ///< which company has exclusivity
-	uint8_t exclusive_counter;       ///< months till the exclusivity expires
-	ReferenceThroughBaseContainer<std::array<int16_t, MAX_COMPANIES>> ratings;  ///< ratings of each company for this town
+	CompanyMask have_ratings{}; ///< which companies have a rating
+	ReferenceThroughBaseContainer<std::array<uint8_t, MAX_COMPANIES>> unwanted{}; ///< how many months companies aren't wanted by towns (bribe)
+	CompanyID exclusivity = CompanyID::Invalid(); ///< which company has exclusivity
+	uint8_t exclusive_counter = 0; ///< months till the exclusivity expires
+	ReferenceThroughBaseContainer<std::array<int16_t, MAX_COMPANIES>> ratings{};  ///< ratings of each company for this town
 
-	TransportedCargoStat<uint32_t> supplied[NUM_CARGO]; ///< Cargo statistics about supplied cargo.
-	TransportedCargoStat<uint16_t> received[NUM_TAE]; ///< Cargo statistics about received cargotypes.
-	uint32_t goal[NUM_TAE]; ///< Amount of cargo required for the town to grow.
+	std::array<TransportedCargoStat<uint32_t>, NUM_CARGO> supplied{}; ///< Cargo statistics about supplied cargo.
+	std::array<TransportedCargoStat<uint16_t>, NUM_TAE> received{}; ///< Cargo statistics about received cargotypes.
+	std::array<uint32_t, NUM_TAE> goal{}; ///< Amount of cargo required for the town to grow.
 
-	std::string text; ///< General text with additional information.
+	std::string text{}; ///< General text with additional information.
 
 	inline uint8_t GetPercentTransported(CargoType cargo_type) const
 	{
@@ -86,22 +86,22 @@ struct Town : TownPool::PoolItem<&_town_pool> {
 		return this->supplied[cargo_type].old_act * 256 / (this->supplied[cargo_type].old_max + 1);
 	}
 
-	StationList stations_near;       ///< NOSAVE: List of nearby stations.
+	StationList stations_near{}; ///< NOSAVE: List of nearby stations.
 
-	uint16_t time_until_rebuild;       ///< time until we rebuild a house
+	uint16_t time_until_rebuild = 0; ///< time until we rebuild a house
 
-	uint16_t grow_counter;             ///< counter to count when to grow, value is smaller than or equal to growth_rate
-	uint16_t growth_rate;              ///< town growth rate
+	uint16_t grow_counter = 0; ///< counter to count when to grow, value is smaller than or equal to growth_rate
+	uint16_t growth_rate = 0; ///< town growth rate
 
-	uint8_t fund_buildings_months;      ///< fund buildings program in action?
-	uint8_t road_build_months;          ///< fund road reconstruction in action?
+	uint8_t fund_buildings_months = 0; ///< fund buildings program in action?
+	uint8_t road_build_months = 0; ///< fund road reconstruction in action?
 
-	bool larger_town;                ///< if this is a larger town and should grow more quickly
-	TownLayout layout;               ///< town specific road layout
+	bool larger_town = false; ///< if this is a larger town and should grow more quickly
+	TownLayout layout{}; ///< town specific road layout
 
-	bool show_zone;                  ///< NOSAVE: mark town to show the local authority zone in the viewports
+	bool show_zone = false; ///< NOSAVE: mark town to show the local authority zone in the viewports
 
-	std::vector<PersistentStorage *> psa_list;
+	std::vector<PersistentStorage *> psa_list{};
 
 	/**
 	 * Creates a new town.

--- a/src/town_type.h
+++ b/src/town_type.h
@@ -113,12 +113,10 @@ static const uint MAX_LENGTH_TOWN_NAME_CHARS = 32; ///< The maximum length of a 
 /** Store the maximum and actually transported cargo amount for the current and the last month. */
 template <typename Tstorage>
 struct TransportedCargoStat {
-	Tstorage old_max;  ///< Maximum amount last month
-	Tstorage new_max;  ///< Maximum amount this month
-	Tstorage old_act;  ///< Actually transported last month
-	Tstorage new_act;  ///< Actually transported this month
-
-	TransportedCargoStat() : old_max(0), new_max(0), old_act(0), new_act(0) {}
+	Tstorage old_max = 0; ///< Maximum amount last month
+	Tstorage new_max = 0; ///< Maximum amount this month
+	Tstorage old_act = 0; ///< Actually transported last month
+	Tstorage new_act = 0; ///< Actually transported this month
 
 	/** Update stats for a new month. */
 	void NewMonth()

--- a/src/train.h
+++ b/src/train.h
@@ -71,14 +71,14 @@ void NormalizeTrainVehInDepot(const Train *u);
 /** Variables that are cached to improve performance and such */
 struct TrainCache {
 	/* Cached wagon override spritegroup */
-	const struct SpriteGroup *cached_override;
+	const struct SpriteGroup *cached_override = nullptr;
 
 	/* cached values, recalculated on load and each time a vehicle is added to/removed from the consist. */
-	bool cached_tilt;           ///< train can tilt; feature provides a bonus in curves
-	uint8_t user_def_data;         ///< Cached property 0x25. Can be set by Callback 0x36.
+	bool cached_tilt = false; ///< train can tilt; feature provides a bonus in curves
+	uint8_t user_def_data = 0; ///< Cached property 0x25. Can be set by Callback 0x36.
 
-	int16_t cached_curve_speed_mod; ///< curve speed modifier of the entire train
-	uint16_t cached_max_curve_speed; ///< max consist speed limited by curves
+	int16_t cached_curve_speed_mod = 0; ///< curve speed modifier of the entire train
+	uint16_t cached_max_curve_speed = 0; ///< max consist speed limited by curves
 
 	auto operator<=>(const TrainCache &) const = default;
 };
@@ -87,20 +87,20 @@ struct TrainCache {
  * 'Train' is either a loco or a wagon.
  */
 struct Train final : public GroundVehicle<Train, VEH_TRAIN> {
-	uint16_t flags;
-	uint16_t crash_anim_pos; ///< Crash animation counter.
-	uint16_t wait_counter; ///< Ticks waiting in front of a signal, ticks being stuck or a counter for forced proceeding through signals.
+	uint16_t flags = 0;
+	uint16_t crash_anim_pos = 0; ///< Crash animation counter.
+	uint16_t wait_counter = 0; ///< Ticks waiting in front of a signal, ticks being stuck or a counter for forced proceeding through signals.
 
-	TrainCache tcache;
+	TrainCache tcache{};
 
 	/* Link between the two ends of a multiheaded engine */
-	Train *other_multiheaded_part;
+	Train *other_multiheaded_part = nullptr;
 
-	RailTypes compatible_railtypes;
-	RailType railtype;
+	RailTypes compatible_railtypes{};
+	RailType railtype = INVALID_RAILTYPE;
 
-	TrackBits track;
-	TrainForceProceeding force_proceed;
+	TrackBits track{};
+	TrainForceProceeding force_proceed{};
 
 	/** We don't want GCC to zero our struct! It already is zeroed and has an index! */
 	Train() : GroundVehicleBase() {}

--- a/src/vehicle_base.h
+++ b/src/vehicle_base.h
@@ -67,12 +67,12 @@ enum NewGRFCacheValidValues : uint8_t {
 /** Cached often queried (NewGRF) values */
 struct NewGRFCache {
 	/* Values calculated when they are requested for the first time after invalidating the NewGRF cache. */
-	uint32_t position_consist_length;   ///< Cache for NewGRF var 40.
-	uint32_t position_same_id_length;   ///< Cache for NewGRF var 41.
-	uint32_t consist_cargo_information; ///< Cache for NewGRF var 42. (Note: The cargotype is untranslated in the cache because the accessing GRF is yet unknown.)
-	uint32_t company_information;       ///< Cache for NewGRF var 43.
-	uint32_t position_in_vehicle;       ///< Cache for NewGRF var 4D.
-	uint8_t  cache_valid;               ///< Bitset that indicates which cache values are valid.
+	uint32_t position_consist_length = 0; ///< Cache for NewGRF var 40.
+	uint32_t position_same_id_length = 0; ///< Cache for NewGRF var 41.
+	uint32_t consist_cargo_information = 0; ///< Cache for NewGRF var 42. (Note: The cargotype is untranslated in the cache because the accessing GRF is yet unknown.)
+	uint32_t company_information = 0; ///< Cache for NewGRF var 43.
+	uint32_t position_in_vehicle = 0; ///< Cache for NewGRF var 4D.
+	uint8_t  cache_valid = 0; ///< Bitset that indicates which cache values are valid.
 
 	auto operator<=>(const NewGRFCache &) const = default;
 };
@@ -123,10 +123,10 @@ enum GroundVehicleSubtypeFlags : uint8_t {
 
 /** Cached often queried values common to all vehicles. */
 struct VehicleCache {
-	uint16_t cached_max_speed;        ///< Maximum speed of the consist (minimum of the max speed of all vehicles in the consist).
-	uint16_t cached_cargo_age_period; ///< Number of ticks before carried cargo is aged.
+	uint16_t cached_max_speed = 0; ///< Maximum speed of the consist (minimum of the max speed of all vehicles in the consist).
+	uint16_t cached_cargo_age_period = 0; ///< Number of ticks before carried cargo is aged.
 
-	uint8_t cached_vis_effect;  ///< Visual effect to show (see #VisualEffect)
+	uint8_t cached_vis_effect = 0;  ///< Visual effect to show (see #VisualEffect)
 
 	auto operator<=>(const VehicleCache &) const = default;
 };
@@ -188,11 +188,11 @@ struct VehicleSpriteSeq {
  * or calculating the viewport.
  */
 struct MutableSpriteCache {
-	Direction last_direction;     ///< Last direction we obtained sprites for
-	bool revalidate_before_draw;  ///< We need to do a GetImage() and check bounds before drawing this sprite
-	bool is_viewport_candidate;   ///< This vehicle can potentially be drawn on a viewport
-	Rect old_coord;               ///< Co-ordinates from the last valid bounding box
-	VehicleSpriteSeq sprite_seq;  ///< Vehicle appearance.
+	Direction last_direction = INVALID_DIR; ///< Last direction we obtained sprites for
+	bool revalidate_before_draw = false; ///< We need to do a GetImage() and check bounds before drawing this sprite
+	bool is_viewport_candidate = false; ///< This vehicle can potentially be drawn on a viewport
+	Rect old_coord{}; ///< Co-ordinates from the last valid bounding box
+	VehicleSpriteSeq sprite_seq{}; ///< Vehicle appearance.
 };
 
 /** A vehicle pool for a little over 1 million vehicles. */
@@ -239,12 +239,12 @@ struct Vehicle : VehiclePool::PoolItem<&_vehicle_pool>, BaseVehicle, BaseConsist
 private:
 	typedef std::list<RefitDesc> RefitList;
 
-	Vehicle *next;                      ///< pointer to the next vehicle in the chain
-	Vehicle *previous;                  ///< NOSAVE: pointer to the previous vehicle in the chain
-	Vehicle *first;                     ///< NOSAVE: pointer to the first vehicle in the chain
+	Vehicle *next = nullptr; ///< pointer to the next vehicle in the chain
+	Vehicle *previous = nullptr; ///< NOSAVE: pointer to the previous vehicle in the chain
+	Vehicle *first = nullptr; ///< NOSAVE: pointer to the first vehicle in the chain
 
-	Vehicle *next_shared;               ///< pointer to the next vehicle that shares the order
-	Vehicle *previous_shared;           ///< NOSAVE: pointer to the previous vehicle in the shared order chain
+	Vehicle *next_shared = nullptr; ///< pointer to the next vehicle that shares the order
+	Vehicle *previous_shared = nullptr; ///< NOSAVE: pointer to the previous vehicle in the shared order chain
 
 public:
 	friend void FixOldVehicles(LoadgameState &ls);
@@ -255,111 +255,111 @@ public:
 	friend class SlVehicleDisaster;
 	friend void Ptrs_VEHS();
 
-	TileIndex tile;                     ///< Current tile index
+	TileIndex tile = INVALID_TILE; ///< Current tile index
 
 	/**
 	 * Heading for this tile.
 	 * For airports and train stations this tile does not necessarily belong to the destination station,
 	 * but it can be used for heuristic purposes to estimate the distance.
 	 */
-	TileIndex dest_tile;
+	TileIndex dest_tile = INVALID_TILE;
 
-	Money profit_this_year;             ///< Profit this year << 8, low 8 bits are fract
-	Money profit_last_year;             ///< Profit last year << 8, low 8 bits are fract
-	Money value;                        ///< Value of the vehicle
+	Money profit_this_year = 0; ///< Profit this year << 8, low 8 bits are fract
+	Money profit_last_year = 0; ///< Profit last year << 8, low 8 bits are fract
+	Money value = 0; ///< Value of the vehicle
 
-	CargoPayment *cargo_payment;        ///< The cargo payment we're currently in
+	CargoPayment *cargo_payment = nullptr; ///< The cargo payment we're currently in
 
-	mutable Rect coord;                 ///< NOSAVE: Graphical bounding box of the vehicle, i.e. what to redraw on moves.
+	mutable Rect coord{}; ///< NOSAVE: Graphical bounding box of the vehicle, i.e. what to redraw on moves.
 
-	Vehicle *hash_viewport_next;        ///< NOSAVE: Next vehicle in the visual location hash.
-	Vehicle **hash_viewport_prev;       ///< NOSAVE: Previous vehicle in the visual location hash.
+	Vehicle *hash_viewport_next = nullptr; ///< NOSAVE: Next vehicle in the visual location hash.
+	Vehicle **hash_viewport_prev = nullptr; ///< NOSAVE: Previous vehicle in the visual location hash.
 
-	Vehicle *hash_tile_next;            ///< NOSAVE: Next vehicle in the tile location hash.
-	Vehicle **hash_tile_prev;           ///< NOSAVE: Previous vehicle in the tile location hash.
-	Vehicle **hash_tile_current;        ///< NOSAVE: Cache of the current hash chain.
+	Vehicle *hash_tile_next = nullptr; ///< NOSAVE: Next vehicle in the tile location hash.
+	Vehicle **hash_tile_prev = nullptr; ///< NOSAVE: Previous vehicle in the tile location hash.
+	Vehicle **hash_tile_current = nullptr; ///< NOSAVE: Cache of the current hash chain.
 
-	SpriteID colourmap;                 ///< NOSAVE: cached colour mapping
+	SpriteID colourmap{}; ///< NOSAVE: cached colour mapping
 
 	/* Related to age and service time */
-	TimerGameCalendar::Year build_year;           ///< Year the vehicle has been built.
-	TimerGameCalendar::Date age;                  ///< Age in calendar days.
-	TimerGameEconomy::Date economy_age;           ///< Age in economy days.
-	TimerGameCalendar::Date max_age;              ///< Maximum age
-	TimerGameEconomy::Date date_of_last_service; ///< Last economy date the vehicle had a service at a depot.
-	TimerGameCalendar::Date date_of_last_service_newgrf; ///< Last calendar date the vehicle had a service at a depot, unchanged by the date cheat to protect against unsafe NewGRF behavior.
-	uint16_t reliability;                 ///< Reliability.
-	uint16_t reliability_spd_dec;         ///< Reliability decrease speed.
-	uint8_t breakdown_ctr;                 ///< Counter for managing breakdown events. @see Vehicle::HandleBreakdown
-	uint8_t breakdown_delay;               ///< Counter for managing breakdown length.
-	uint8_t breakdowns_since_last_service; ///< Counter for the amount of breakdowns.
-	uint8_t breakdown_chance;              ///< Current chance of breakdowns.
+	TimerGameCalendar::Year build_year{}; ///< Year the vehicle has been built.
+	TimerGameCalendar::Date age{}; ///< Age in calendar days.
+	TimerGameEconomy::Date economy_age{}; ///< Age in economy days.
+	TimerGameCalendar::Date max_age{}; ///< Maximum age
+	TimerGameEconomy::Date date_of_last_service{}; ///< Last economy date the vehicle had a service at a depot.
+	TimerGameCalendar::Date date_of_last_service_newgrf{}; ///< Last calendar date the vehicle had a service at a depot, unchanged by the date cheat to protect against unsafe NewGRF behavior.
+	uint16_t reliability = 0; ///< Reliability.
+	uint16_t reliability_spd_dec = 0; ///< Reliability decrease speed.
+	uint8_t breakdown_ctr = 0; ///< Counter for managing breakdown events. @see Vehicle::HandleBreakdown
+	uint8_t breakdown_delay = 0; ///< Counter for managing breakdown length.
+	uint8_t breakdowns_since_last_service = 0; ///< Counter for the amount of breakdowns.
+	uint8_t breakdown_chance = 0; ///< Current chance of breakdowns.
 
-	int32_t x_pos;                        ///< x coordinate.
-	int32_t y_pos;                        ///< y coordinate.
-	int32_t z_pos;                        ///< z coordinate.
-	Direction direction;                ///< facing
+	int32_t x_pos = 0; ///< x coordinate.
+	int32_t y_pos = 0; ///< y coordinate.
+	int32_t z_pos = 0; ///< z coordinate.
+	Direction direction = INVALID_DIR; ///< facing
 
-	Owner owner;                        ///< Which company owns the vehicle?
+	Owner owner = INVALID_OWNER; ///< Which company owns the vehicle?
 	/**
 	 * currently displayed sprite index
 	 * 0xfd == custom sprite, 0xfe == custom second head sprite
 	 * 0xff == reserved for another custom sprite
 	 */
-	uint8_t spritenum;
-	uint8_t x_extent;                      ///< x-extent of vehicle bounding box
-	uint8_t y_extent;                      ///< y-extent of vehicle bounding box
-	uint8_t z_extent;                      ///< z-extent of vehicle bounding box
-	int8_t x_bb_offs;                     ///< x offset of vehicle bounding box
-	int8_t y_bb_offs;                     ///< y offset of vehicle bounding box
-	int8_t x_offs;                        ///< x offset for vehicle sprite
-	int8_t y_offs;                        ///< y offset for vehicle sprite
-	EngineID engine_type;               ///< The type of engine used for this vehicle.
+	uint8_t spritenum = 0;
+	uint8_t x_extent = 0; ///< x-extent of vehicle bounding box
+	uint8_t y_extent = 0; ///< y-extent of vehicle bounding box
+	uint8_t z_extent = 0; ///< z-extent of vehicle bounding box
+	int8_t x_bb_offs = 0; ///< x offset of vehicle bounding box
+	int8_t y_bb_offs = 0; ///< y offset of vehicle bounding box
+	int8_t x_offs = 0; ///< x offset for vehicle sprite
+	int8_t y_offs = 0; ///< y offset for vehicle sprite
+	EngineID engine_type = EngineID::Invalid(); ///< The type of engine used for this vehicle.
 
-	TextEffectID fill_percent_te_id;    ///< a text-effect id to a loading indicator object
-	UnitID unitnumber;                  ///< unit number, for display purposes only
+	TextEffectID fill_percent_te_id = INVALID_TE_ID; ///< a text-effect id to a loading indicator object
+	UnitID unitnumber{}; ///< unit number, for display purposes only
 
-	uint16_t cur_speed;                   ///< current speed
-	uint8_t subspeed;                      ///< fractional speed
-	uint8_t acceleration;                  ///< used by train & aircraft
-	uint32_t motion_counter;              ///< counter to occasionally play a vehicle sound.
-	uint8_t progress;                      ///< The percentage (if divided by 256) this vehicle already crossed the tile unit.
+	uint16_t cur_speed = 0; ///< current speed
+	uint8_t subspeed = 0; ///< fractional speed
+	uint8_t acceleration = 0; ///< used by train & aircraft
+	uint32_t motion_counter = 0; ///< counter to occasionally play a vehicle sound.
+	uint8_t progress = 0; ///< The percentage (if divided by 256) this vehicle already crossed the tile unit.
 
-	uint8_t waiting_triggers;              ///< Triggers to be yet matched before rerandomizing the random bits.
-	uint16_t random_bits; ///< Bits used for randomized variational spritegroups.
+	uint8_t waiting_triggers = 0; ///< Triggers to be yet matched before rerandomizing the random bits.
+	uint16_t random_bits = 0; ///< Bits used for randomized variational spritegroups.
 
-	StationID last_station_visited;     ///< The last station we stopped at.
-	StationID last_loading_station;     ///< Last station the vehicle has stopped at and could possibly leave from with any cargo loaded.
-	TimerGameTick::TickCounter last_loading_tick; ///< Last TimerGameTick::counter tick that the vehicle has stopped at a station and could possibly leave with any cargo loaded.
+	StationID last_station_visited = StationID::Invalid(); ///< The last station we stopped at.
+	StationID last_loading_station = StationID::Invalid(); ///< Last station the vehicle has stopped at and could possibly leave from with any cargo loaded.
+	TimerGameTick::TickCounter last_loading_tick{}; ///< Last TimerGameTick::counter tick that the vehicle has stopped at a station and could possibly leave with any cargo loaded.
 
-	VehicleCargoList cargo;             ///< The cargo this vehicle is carrying
-	CargoType cargo_type;                 ///< type of cargo this vehicle is carrying
-	uint8_t cargo_subtype;                 ///< Used for livery refits (NewGRF variations)
-	uint16_t cargo_cap;                   ///< total capacity
-	uint16_t refit_cap;                   ///< Capacity left over from before last refit.
-	uint16_t cargo_age_counter;           ///< Ticks till cargo is aged next.
-	int8_t trip_occupancy;                ///< NOSAVE: Occupancy of vehicle of the current trip (updated after leaving a station).
+	VehicleCargoList cargo{}; ///< The cargo this vehicle is carrying
+	CargoType cargo_type{}; ///< type of cargo this vehicle is carrying
+	uint8_t cargo_subtype = 0; ///< Used for livery refits (NewGRF variations)
+	uint16_t cargo_cap = 0; ///< total capacity
+	uint16_t refit_cap = 0; ///< Capacity left over from before last refit.
+	uint16_t cargo_age_counter = 0; ///< Ticks till cargo is aged next.
+	int8_t trip_occupancy = 0; ///< NOSAVE: Occupancy of vehicle of the current trip (updated after leaving a station).
 
-	uint8_t day_counter;                   ///< Increased by one for each day
-	uint8_t tick_counter;                  ///< Increased by one for each tick
-	uint8_t running_ticks;                 ///< Number of ticks this vehicle was not stopped this day
-	uint16_t load_unload_ticks;           ///< Ticks to wait before starting next cycle.
+	uint8_t day_counter = 0; ///< Increased by one for each day
+	uint8_t tick_counter = 0; ///< Increased by one for each tick
+	uint8_t running_ticks = 0; ///< Number of ticks this vehicle was not stopped this day
+	uint16_t load_unload_ticks = 0; ///< Ticks to wait before starting next cycle.
 
-	uint8_t vehstatus;                     ///< Status
-	uint8_t subtype;                       ///< subtype (Filled with values from #AircraftSubType/#DisasterSubType/#EffectVehicleType/#GroundVehicleSubtypeFlags)
-	Order current_order;                ///< The current order (+ status, like: loading)
+	uint8_t vehstatus = 0; ///< Status
+	uint8_t subtype = 0; ///< subtype (Filled with values from #AircraftSubType/#DisasterSubType/#EffectVehicleType/#GroundVehicleSubtypeFlags)
+	Order current_order{}; ///< The current order (+ status, like: loading)
 
 	union {
-		OrderList *orders;              ///< Pointer to the order list for this vehicle
-		Order *old_orders;              ///< Only used during conversion of old save games
+		OrderList *orders = nullptr; ///< Pointer to the order list for this vehicle
+		Order *old_orders; ///< Only used during conversion of old save games
 	};
 
-	NewGRFCache grf_cache;              ///< Cache of often used calculated NewGRF values
-	VehicleCache vcache;                ///< Cache of often used vehicle values.
+	NewGRFCache grf_cache{}; ///< Cache of often used calculated NewGRF values
+	VehicleCache vcache{}; ///< Cache of often used vehicle values.
 
-	GroupID group_id;                   ///< Index of group Pool array
+	GroupID group_id = GroupID::Invalid(); ///< Index of group Pool array
 
-	mutable MutableSpriteCache sprite_cache; ///< Cache of sprites and values related to recalculating them, see #MutableSpriteCache
+	mutable MutableSpriteCache sprite_cache{}; ///< Cache of sprites and values related to recalculating them, see #MutableSpriteCache
 
 	/**
 	 * Calculates the weight value that this vehicle will have when fully loaded with its current cargo.

--- a/src/vehicle_type.h
+++ b/src/vehicle_type.h
@@ -47,9 +47,8 @@ struct EffectVehicle;
 struct DisasterVehicle;
 
 /** Base vehicle class. */
-struct BaseVehicle
-{
-	VehicleType type; ///< Type of vehicle
+struct BaseVehicle {
+	VehicleType type = VEH_INVALID; ///< Type of vehicle
 };
 
 /** Flags for goto depot commands. */

--- a/src/viewport_type.h
+++ b/src/viewport_type.h
@@ -47,10 +47,10 @@ struct Viewport {
 
 /** Location information about a sign as seen on the viewport */
 struct ViewportSign {
-	int32_t center;        ///< The center position of the sign
-	int32_t top;           ///< The top of the sign
-	uint16_t width_normal; ///< The width when not zoomed out (normal font)
-	uint16_t width_small;  ///< The width when zoomed out (small font)
+	int32_t center = 0; ///< The center position of the sign
+	int32_t top = 0; ///< The top of the sign
+	uint16_t width_normal = 0; ///< The width when not zoomed out (normal font)
+	uint16_t width_small = 0; ///< The width when zoomed out (small font)
 
 	auto operator<=>(const ViewportSign &) const = default;
 
@@ -60,7 +60,7 @@ struct ViewportSign {
 
 /** Specialised ViewportSign that tracks whether it is valid for entering into a Kdtree */
 struct TrackedViewportSign : ViewportSign {
-	bool kdtree_valid; ///< Are the sign data valid for use with the _viewport_sign_kdtree?
+	bool kdtree_valid = false; ///< Are the sign data valid for use with the _viewport_sign_kdtree?
 
 	auto operator<=>(const TrackedViewportSign &) const = default;
 
@@ -72,11 +72,6 @@ struct TrackedViewportSign : ViewportSign {
 	{
 		this->kdtree_valid = true;
 		this->ViewportSign::UpdatePosition(center, top, str, str_small);
-	}
-
-
-	TrackedViewportSign() : kdtree_valid{ false }
-	{
 	}
 };
 

--- a/src/waypoint_base.h
+++ b/src/waypoint_base.h
@@ -21,9 +21,9 @@ enum WaypointFlags : uint8_t {
 
 /** Representation of a waypoint. */
 struct Waypoint final : SpecializedStation<Waypoint, true> {
-	uint16_t town_cn;    ///< The N-1th waypoint for this town (consecutive number)
+	uint16_t town_cn = 0; ///< The N-1th waypoint for this town (consecutive number)
 	uint16_t waypoint_flags{}; ///< Waypoint flags, see WaypointFlags
-	TileArea road_waypoint_area; ///< Tile area the road waypoint part covers
+	TileArea road_waypoint_area{}; ///< Tile area the road waypoint part covers
 
 	/**
 	 * Create a waypoint at the given tile.


### PR DESCRIPTION
Commit message:
Fix (#13454): Edited GetClearGround(Tile t) function

## Motivation / Problem
https://github.com/OpenTTD/OpenTTD/issues/13454


## Description
The GetClearGround(Tile t) function would automatically return CLEAR_SNOW if it was a snow tile which would cause CLEAR_ROCKS to be unable to spawn in the same tile as snow, so to fix this I added an if statement to check if the raw data was CLEAR_ROCKS and then returned CLEAR_ROCKS if it was.

## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
